### PR TITLE
Search User by it's username

### DIFF
--- a/src/main/java/com/safetypin/authentication/controller/SearchController.java
+++ b/src/main/java/com/safetypin/authentication/controller/SearchController.java
@@ -1,0 +1,32 @@
+package com.safetypin.authentication.controller;
+
+import com.safetypin.authentication.model.User;
+import com.safetypin.authentication.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+public class SearchController {
+    private final UserService userService;
+
+    public SearchController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<User>> searchUsersByName(@RequestParam(required = false) String query) {
+        List<User> users;
+        if (query == null || query.trim().isEmpty()) {
+            users = userService.findAllUsers(); // Fetch all users if no query is provided
+        } else {
+            users = userService.findUsersByNameContaining(query);
+        }
+        return ResponseEntity.ok(users);
+    }
+}

--- a/src/main/java/com/safetypin/authentication/controller/SearchController.java
+++ b/src/main/java/com/safetypin/authentication/controller/SearchController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/users")

--- a/src/main/java/com/safetypin/authentication/controller/SearchController.java
+++ b/src/main/java/com/safetypin/authentication/controller/SearchController.java
@@ -1,5 +1,6 @@
 package com.safetypin.authentication.controller;
 
+import com.safetypin.authentication.dto.UserResponse;
 import com.safetypin.authentication.model.User;
 import com.safetypin.authentication.service.UserService;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/users")
@@ -20,13 +22,16 @@ public class SearchController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<List<User>> searchUsersByName(@RequestParam(required = false) String query) {
+    public ResponseEntity<List<UserResponse>> searchUsersByName(@RequestParam(required = false) String query) {
         List<User> users;
         if (query == null || query.trim().isEmpty()) {
             users = userService.findAllUsers(); // Fetch all users if no query is provided
         } else {
             users = userService.findUsersByNameContaining(query);
         }
-        return ResponseEntity.ok(users);
+        List<UserResponse> userResponses = users.stream()
+                .map(User::generateUserResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(userResponses);
     }
 }

--- a/src/main/java/com/safetypin/authentication/controller/SearchController.java
+++ b/src/main/java/com/safetypin/authentication/controller/SearchController.java
@@ -26,7 +26,7 @@ public class SearchController {
         if (query == null || query.trim().isEmpty()) {
             users = userService.findAllUsers(); // Fetch all users if no query is provided
         } else {
-            users = userService.findUsersByNameContaining(query);
+            users = userService.findUsersByNameContaining(query.trim());
         }
         List<UserResponse> userResponses = users.stream()
                 .map(User::generateUserResponse)

--- a/src/main/java/com/safetypin/authentication/controller/SearchController.java
+++ b/src/main/java/com/safetypin/authentication/controller/SearchController.java
@@ -31,7 +31,7 @@ public class SearchController {
         }
         List<UserResponse> userResponses = users.stream()
                 .map(User::generateUserResponse)
-                .collect(Collectors.toList());
+                .toList();
         return ResponseEntity.ok(userResponses);
     }
 }

--- a/src/main/java/com/safetypin/authentication/repository/UserRepository.java
+++ b/src/main/java/com/safetypin/authentication/repository/UserRepository.java
@@ -5,6 +5,7 @@ import com.safetypin.authentication.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
@@ -12,4 +13,5 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     User findByEmail(String email);
 
     User findByRole(Role role);
+    List<User> findByNameContainingIgnoreCase(String name);
 }

--- a/src/main/java/com/safetypin/authentication/service/UserService.java
+++ b/src/main/java/com/safetypin/authentication/service/UserService.java
@@ -4,6 +4,7 @@ import com.safetypin.authentication.model.User;
 import com.safetypin.authentication.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -25,5 +26,12 @@ public class UserService {
 
     public User save(User user) {
         return userRepository.save(user);
+    }
+
+    public List<User> findUsersByNameContaining(String query) {
+        return userRepository.findByNameContainingIgnoreCase(query);
+    }
+    public List<User> findAllUsers() {
+        return userRepository.findAll();
     }
 }

--- a/src/test/java/com/safetypin/authentication/controller/SearchControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/SearchControllerTest.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // Keep the same instance for DB setup
 @Transactional // Rollback after each test
-public class SearchControllerTest {
+class SearchControllerTest {
 
 
     @Autowired

--- a/src/test/java/com/safetypin/authentication/controller/SearchControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/SearchControllerTest.java
@@ -1,0 +1,78 @@
+package com.safetypin.authentication.controller;
+
+import com.safetypin.authentication.model.User;
+import com.safetypin.authentication.repository.UserRepository;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import com.safetypin.authentication.model.Role;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT) // Load full app
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS) // Keep the same instance for DB setup
+@Transactional // Rollback after each test
+public class SearchControllerTest {
+
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository; // Use actual repository
+
+    @BeforeAll
+    void setUp() {
+        userRepository.deleteAll(); // Clean DB before tests
+
+        // Insert real users into the database with non-nullable fields
+        User user1 = new User();
+        user1.setName("John Doe");
+        user1.setEmail("john.doe@example.com");
+        user1.setRole(Role.REGISTERED_USER);
+
+        User user2 = new User();
+        user2.setName("John Richard");
+        user2.setEmail("john.richard@example.com");
+        user2.setRole(Role.REGISTERED_USER);
+
+        User user3 = new User();
+        user3.setName("Koala Kom");
+        user3.setEmail("koala.kom@example.com");
+        user3.setRole(Role.REGISTERED_USER);
+
+        userRepository.saveAll(List.of(user1, user2, user3));
+    }
+
+    @Test
+    void testSearchMultipleUsersByName() throws Exception {
+
+        mockMvc.perform(get("/api/users/search")
+                        .param("query", "john")) // Actual DB query
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(2)) // Expect only 2 users with "John"
+                .andExpect(jsonPath("$[0].name").value("John Doe"))
+                .andExpect(jsonPath("$[1].name").value("John Richard"));
+    }
+
+    @Test
+    void testSearchAllUsersWhenNoQueryProvided() throws Exception {
+        mockMvc.perform(get("/api/users/search")) // No query parameter
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(3)) // Expect all 3 users
+                .andExpect(jsonPath("$[0].name").value("John Doe"))
+                .andExpect(jsonPath("$[1].name").value("John Richard"))
+                .andExpect(jsonPath("$[2].name").value("Koala Kom"));
+    }
+}

--- a/src/test/java/com/safetypin/authentication/controller/SearchControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/SearchControllerTest.java
@@ -75,4 +75,15 @@ class SearchControllerTest {
                 .andExpect(jsonPath("$[1].name").value("John Richard"))
                 .andExpect(jsonPath("$[2].name").value("Koala Kom"));
     }
+
+    @Test
+    void testSearchAllUsersWhenEmptyQuery() throws Exception {
+        mockMvc.perform(get("/api/users/search")
+                        .param("query", "   "))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(3)) // Expect all 3 users
+                .andExpect(jsonPath("$[0].name").value("John Doe"))
+                .andExpect(jsonPath("$[1].name").value("John Richard"))
+                .andExpect(jsonPath("$[2].name").value("Koala Kom"));
+    }
 }


### PR DESCRIPTION
This PR introduces a new controller: SearchController, which includes the endpoint:

📌 GET /api/users/search – Allows searching for users by a substring in their name.

I’d love your feedback on the following:
- Should JWT access token validation be required for this endpoint before returning results?
- Is there any other modification that should be done?

Let me know your thoughts.