### PR TITLE
Fetch username & profile picture with batch

### DIFF
--- a/src/main/java/com/safetypin/authentication/controller/ProfileController.java
+++ b/src/main/java/com/safetypin/authentication/controller/ProfileController.java
@@ -1,16 +1,20 @@
 package com.safetypin.authentication.controller;
 
 import com.safetypin.authentication.dto.AuthResponse;
+import com.safetypin.authentication.dto.PostedByData;
 import com.safetypin.authentication.dto.ProfileResponse;
 import com.safetypin.authentication.dto.UpdateProfileRequest;
 import com.safetypin.authentication.exception.InvalidCredentialsException;
 import com.safetypin.authentication.exception.ResourceNotFoundException;
 import com.safetypin.authentication.service.ProfileService;
+import com.safetypin.authentication.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @RestController
@@ -18,10 +22,12 @@ import java.util.UUID;
 public class ProfileController {
 
     private final ProfileService profileService;
+    private final UserService userService;
 
     @Autowired
-    public ProfileController(ProfileService profileService) {
+    public ProfileController(ProfileService profileService, UserService userService) {
         this.profileService = profileService;
+        this.userService = userService;
     }
 
     @GetMapping("/{id}")
@@ -60,5 +66,10 @@ public class ProfileController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(new AuthResponse(false, "Error updating profile: " + e.getMessage(), null));
         }
+    }
+
+    @PostMapping("/batch")
+    public Map<UUID, PostedByData> getUsersBatch(@RequestBody List<UUID> userIds) {
+        return profileService.getUsersBatch(userIds);
     }
 }

--- a/src/main/java/com/safetypin/authentication/controller/ProfileController.java
+++ b/src/main/java/com/safetypin/authentication/controller/ProfileController.java
@@ -17,7 +17,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -26,14 +25,12 @@ import java.util.UUID;
 public class ProfileController {
 
     private final ProfileService profileService;
-    private final UserService userService;
 
     private final JwtService jwtService;
 
     @Autowired
-    public ProfileController(ProfileService profileService, UserService userService, JwtService jwtService) {
+    public ProfileController(ProfileService profileService, JwtService jwtService) {
         this.profileService = profileService;
-        this.userService = userService;
         this.jwtService = jwtService;
     }
 

--- a/src/main/java/com/safetypin/authentication/controller/ProfileController.java
+++ b/src/main/java/com/safetypin/authentication/controller/ProfileController.java
@@ -1,30 +1,18 @@
 package com.safetypin.authentication.controller;
 
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.safetypin.authentication.dto.AuthResponse;
-import com.safetypin.authentication.dto.PostedByData;
-import com.safetypin.authentication.dto.ProfileResponse;
-import com.safetypin.authentication.dto.UpdateProfileRequest;
-import com.safetypin.authentication.dto.UserResponse;
+import com.safetypin.authentication.dto.*;
 import com.safetypin.authentication.exception.InvalidCredentialsException;
 import com.safetypin.authentication.exception.ResourceNotFoundException;
 import com.safetypin.authentication.service.JwtService;
 import com.safetypin.authentication.service.ProfileService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/profiles")

--- a/src/main/java/com/safetypin/authentication/controller/ProfileController.java
+++ b/src/main/java/com/safetypin/authentication/controller/ProfileController.java
@@ -1,24 +1,30 @@
 package com.safetypin.authentication.controller;
 
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.safetypin.authentication.dto.AuthResponse;
 import com.safetypin.authentication.dto.PostedByData;
 import com.safetypin.authentication.dto.ProfileResponse;
 import com.safetypin.authentication.dto.UpdateProfileRequest;
-import com.safetypin.authentication.dto.UserPostResponse;
 import com.safetypin.authentication.dto.UserResponse;
 import com.safetypin.authentication.exception.InvalidCredentialsException;
 import com.safetypin.authentication.exception.ResourceNotFoundException;
 import com.safetypin.authentication.service.JwtService;
 import com.safetypin.authentication.service.ProfileService;
-import com.safetypin.authentication.service.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/profiles")
@@ -99,17 +105,5 @@ public class ProfileController {
     @PostMapping("/batch")
     public Map<UUID, PostedByData> getUsersBatch(@RequestBody List<UUID> userIds) {
         return profileService.getUsersBatch(userIds);
-    }
-
-    // DEPRECIATED (REPLACED WITH /batch)
-    @GetMapping
-    public ResponseEntity<AuthResponse> getAllProfiles() {
-        try {
-            List<UserPostResponse> profiles = profileService.getAllProfiles();
-            return ResponseEntity.ok(new AuthResponse(true, "All profiles retrieved successfully", profiles));
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new AuthResponse(false, "Error retrieving profiles: " + e.getMessage(), null));
-        }
     }
 }

--- a/src/main/java/com/safetypin/authentication/controller/SearchController.java
+++ b/src/main/java/com/safetypin/authentication/controller/SearchController.java
@@ -1,15 +1,17 @@
 package com.safetypin.authentication.controller;
 
-import com.safetypin.authentication.dto.UserResponse;
-import com.safetypin.authentication.model.User;
-import com.safetypin.authentication.service.UserService;
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
+// Import PostMapping
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import com.safetypin.authentication.dto.UserResponse; // Add missing import
+import com.safetypin.authentication.model.User;
+import com.safetypin.authentication.service.UserService;
 
 @RestController
 @RequestMapping("/api/users")
@@ -30,7 +32,7 @@ public class SearchController {
         }
         List<UserResponse> userResponses = users.stream()
                 .map(User::generateUserResponse)
-                .toList();
+                .toList(); // Use toList()
         return ResponseEntity.ok(userResponses);
     }
 }

--- a/src/main/java/com/safetypin/authentication/controller/SearchController.java
+++ b/src/main/java/com/safetypin/authentication/controller/SearchController.java
@@ -1,17 +1,15 @@
 package com.safetypin.authentication.controller;
 
-import java.util.List;
-
+import com.safetypin.authentication.dto.UserResponse;
+import com.safetypin.authentication.model.User;
+import com.safetypin.authentication.service.UserService;
 import org.springframework.http.ResponseEntity;
-// Import PostMapping
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.safetypin.authentication.dto.UserResponse; // Add missing import
-import com.safetypin.authentication.model.User;
-import com.safetypin.authentication.service.UserService;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/users")

--- a/src/main/java/com/safetypin/authentication/dto/PostedByData.java
+++ b/src/main/java/com/safetypin/authentication/dto/PostedByData.java
@@ -1,16 +1,16 @@
 package com.safetypin.authentication.dto;
 
+import java.util.UUID;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-
-import java.util.UUID;
 
 @Data
 @Builder
 @AllArgsConstructor
 public class PostedByData {
-    private UUID userId;
+    private UUID userId; // Changed from userId to id
     private String name;
     private String profilePicture; // URL or base64, depending on your system
 

--- a/src/main/java/com/safetypin/authentication/dto/PostedByData.java
+++ b/src/main/java/com/safetypin/authentication/dto/PostedByData.java
@@ -1,5 +1,6 @@
 package com.safetypin.authentication.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,6 +8,7 @@ import java.util.UUID;
 
 @Data
 @Builder
+@AllArgsConstructor
 public class PostedByData {
     private UUID userId;
     private String name;

--- a/src/main/java/com/safetypin/authentication/dto/PostedByData.java
+++ b/src/main/java/com/safetypin/authentication/dto/PostedByData.java
@@ -1,10 +1,10 @@
 package com.safetypin.authentication.dto;
 
-import java.util.UUID;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+
+import java.util.UUID;
 
 @Data
 @Builder

--- a/src/main/java/com/safetypin/authentication/dto/PostedByData.java
+++ b/src/main/java/com/safetypin/authentication/dto/PostedByData.java
@@ -1,0 +1,15 @@
+package com.safetypin.authentication.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@Builder
+public class PostedByData {
+    private UUID userId;
+    private String name;
+    private String profilePicture; // URL or base64, depending on your system
+
+}

--- a/src/main/java/com/safetypin/authentication/dto/ProfileResponse.java
+++ b/src/main/java/com/safetypin/authentication/dto/ProfileResponse.java
@@ -11,8 +11,10 @@ import java.util.UUID;
 @Getter
 @Setter
 @Builder
+// used for get & edit profile
 public class ProfileResponse {
     private UUID id;
+    private String name;
     private String role;
     private boolean isVerified;
     private String instagram;
@@ -22,4 +24,5 @@ public class ProfileResponse {
     private String discord;
     private String profilePicture;
     private String profileBanner;
+
 }

--- a/src/main/java/com/safetypin/authentication/dto/ProfileResponse.java
+++ b/src/main/java/com/safetypin/authentication/dto/ProfileResponse.java
@@ -20,4 +20,6 @@ public class ProfileResponse {
     private String line;
     private String tiktok;
     private String discord;
+    private String profilePicture;
+    private String profileBanner;
 }

--- a/src/main/java/com/safetypin/authentication/dto/UserProfileBatchRequest.java
+++ b/src/main/java/com/safetypin/authentication/dto/UserProfileBatchRequest.java
@@ -1,0 +1,15 @@
+package com.safetypin.authentication.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileBatchRequest {
+    private List<UUID> userIds;
+}

--- a/src/main/java/com/safetypin/authentication/dto/UserProfileBatchRequest.java
+++ b/src/main/java/com/safetypin/authentication/dto/UserProfileBatchRequest.java
@@ -1,11 +1,11 @@
 package com.safetypin.authentication.dto;
 
-import java.util.List;
-import java.util.UUID;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
 
 @Data
 @NoArgsConstructor

--- a/src/main/java/com/safetypin/authentication/dto/UserProfileBatchResponse.java
+++ b/src/main/java/com/safetypin/authentication/dto/UserProfileBatchResponse.java
@@ -1,0 +1,14 @@
+package com.safetypin.authentication.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileBatchResponse {
+    private List<PostedByData> profiles;
+}

--- a/src/main/java/com/safetypin/authentication/dto/UserProfileBatchResponse.java
+++ b/src/main/java/com/safetypin/authentication/dto/UserProfileBatchResponse.java
@@ -1,10 +1,10 @@
 package com.safetypin.authentication.dto;
 
-import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Data
 @NoArgsConstructor

--- a/src/main/java/com/safetypin/authentication/dto/UserResponse.java
+++ b/src/main/java/com/safetypin/authentication/dto/UserResponse.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @Builder
+// Yang disimpan di dalam JWT
 public class UserResponse {
     private UUID id;
 

--- a/src/main/java/com/safetypin/authentication/model/User.java
+++ b/src/main/java/com/safetypin/authentication/model/User.java
@@ -1,14 +1,22 @@
 package com.safetypin.authentication.model;
 
+import java.time.LocalDate;
+import java.util.UUID;
+
 import com.safetypin.authentication.dto.UserResponse;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.time.LocalDate;
-import java.util.UUID;
 
 @Entity
 @Table(name = "users")
@@ -36,6 +44,7 @@ public class User {
     @Column(nullable = false)
     private String name;
 
+    @Getter // Explicitly add getter for boolean field for Jackson/Lombok interaction
     @Column(nullable = false)
     private boolean isVerified = false;
 
@@ -51,7 +60,7 @@ public class User {
 
     @Setter
     @Getter
-    private String provider;  // "EMAIL", "GOOGLE", "APPLE"
+    private String provider; // "EMAIL", "GOOGLE", "APPLE"
 
     @Setter
     @Getter
@@ -81,17 +90,6 @@ public class User {
     @Getter
     private String profileBanner;
 
-
-    // Getters and setters
-
-    public boolean isVerified() {
-        return isVerified;
-    }
-
-    public void setVerified(boolean verified) {
-        isVerified = verified;
-    }
-
     // used for jwt
     public UserResponse generateUserResponse() {
         return UserResponse.builder()
@@ -101,7 +99,7 @@ public class User {
                 .birthdate(birthdate)
                 .role(role != null ? role.name() : null)
                 .name(name)
-                .isVerified(isVerified)
+                .isVerified(this.isVerified()) // Explicitly call the getter
                 .profilePicture(profilePicture)
                 .profileBanner(profileBanner)
                 .build();

--- a/src/main/java/com/safetypin/authentication/model/User.java
+++ b/src/main/java/com/safetypin/authentication/model/User.java
@@ -1,22 +1,14 @@
 package com.safetypin.authentication.model;
 
-import java.time.LocalDate;
-import java.util.UUID;
-
 import com.safetypin.authentication.dto.UserResponse;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.UUID;
 
 @Entity
 @Table(name = "users")

--- a/src/main/java/com/safetypin/authentication/model/User.java
+++ b/src/main/java/com/safetypin/authentication/model/User.java
@@ -71,6 +71,15 @@ public class User {
     @Getter
     private String discord;
 
+    @Setter
+    @Getter
+    private String profilePicture;
+
+    @Setter
+    @Getter
+    private String profileBanner;
+
+
     // Getters and setters
 
     public boolean isVerified() {
@@ -81,6 +90,7 @@ public class User {
         isVerified = verified;
     }
 
+    // used for jwt
     public UserResponse generateUserResponse() {
         return UserResponse.builder()
                 .email(email)

--- a/src/main/java/com/safetypin/authentication/service/GoogleAuthService.java
+++ b/src/main/java/com/safetypin/authentication/service/GoogleAuthService.java
@@ -217,25 +217,25 @@ public class GoogleAuthService {
             return null;
         }
     }
-    
+
     private HttpURLConnection createConnectionWithProxy(URL url) throws IOException {
         // Try HTTPS proxy
         if (httpsProxy != null && !httpsProxy.isEmpty()) {
             HttpURLConnection conn = tryProxyConnection(url, httpsProxy, "HTTPS");
             if (conn != null) return conn;
         }
-        
+
         // Try HTTP proxy
         if (httpProxy != null && !httpProxy.isEmpty()) {
             HttpURLConnection conn = tryProxyConnection(url, httpProxy, "HTTP");
             if (conn != null) return conn;
         }
-        
+
         // Use direct connection
         logger.info("No proxy configured, using direct connection");
         return openDirectConnection(url);
     }
-    
+
     private HttpURLConnection tryProxyConnection(URL url, String proxyUrl, String proxyType) throws IOException {
         try {
             URL parsedProxyUrl = createURL(proxyUrl);
@@ -250,7 +250,7 @@ public class GoogleAuthService {
             return null;
         }
     }
-    
+
     private String executeRequest(HttpURLConnection conn, String accessToken) throws IOException {
         try {
             // Set connection properties
@@ -259,18 +259,18 @@ public class GoogleAuthService {
             conn.setRequestMethod("GET");
             conn.setRequestProperty("Authorization", "Bearer " + accessToken);
             conn.setRequestProperty("Accept", "application/json");
-            
+
             logger.info("Opening connection to Google API...");
-            
+
             int responseCode = conn.getResponseCode();
             logger.info("Google API response code: {}", responseCode);
-            
+
             return handleResponse(conn, responseCode);
         } finally {
             conn.disconnect();
         }
     }
-    
+
     private String handleResponse(HttpURLConnection conn, int responseCode) throws IOException {
         if (responseCode == HttpURLConnection.HTTP_OK) {
             String response = readResponse(conn.getInputStream());
@@ -280,7 +280,7 @@ public class GoogleAuthService {
             return handleErrorResponse(conn, responseCode);
         }
     }
-    
+
     private String handleErrorResponse(HttpURLConnection conn, int responseCode) {
         String errorResponse = null;
         try {
@@ -288,7 +288,7 @@ public class GoogleAuthService {
         } catch (Exception e) {
             logger.error("Could not read error response", e);
         }
-        logger.error("Error fetching data from Google API: HTTP {}, Error: {}", 
+        logger.error("Error fetching data from Google API: HTTP {}, Error: {}",
                 responseCode, errorResponse);
         return null;
     }

--- a/src/main/java/com/safetypin/authentication/service/ProfileService.java
+++ b/src/main/java/com/safetypin/authentication/service/ProfileService.java
@@ -1,5 +1,16 @@
 package com.safetypin.authentication.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.safetypin.authentication.dto.PostedByData;
 import com.safetypin.authentication.dto.ProfileResponse;
 import com.safetypin.authentication.dto.UpdateProfileRequest;
@@ -8,16 +19,6 @@ import com.safetypin.authentication.exception.InvalidCredentialsException;
 import com.safetypin.authentication.exception.ResourceNotFoundException;
 import com.safetypin.authentication.model.User;
 import com.safetypin.authentication.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 @Service
 public class ProfileService {
@@ -54,11 +55,9 @@ public class ProfileService {
 
     @Transactional
     public ProfileResponse updateProfile(UUID userId, UpdateProfileRequest request, String token) {
-        // Verify the JWT token and get the user
         try {
             UUID tokenUserId = UUID.fromString(jwtService.parseToken(token).getSubject());
 
-            // Check if token user ID matches the requested user ID
             if (!tokenUserId.equals(userId)) {
                 throw new InvalidCredentialsException("You are not authorized to update this profile");
             }
@@ -66,17 +65,32 @@ public class ProfileService {
             User user = userService.findById(userId)
                     .orElseThrow(() -> new ResourceNotFoundException("User not found with id " + userId));
 
-            // Extract usernames from social media URLs and update fields
-            user.setInstagram(extractInstagramUsername(request.getInstagram()));
-            user.setTwitter(extractTwitterUsername(request.getTwitter()));
-            user.setLine(extractLineUsername(request.getLine()));
-            user.setTiktok(extractTiktokUsername(request.getTiktok()));
-            user.setDiscord(extractDiscordId(request.getDiscord()));
-            user.setProfilePicture(request.getProfilePicture());
-            user.setProfileBanner(request.getProfileBanner());
+            // Update fields only if they are provided (not null) in the request
+            if (request.getInstagram() != null) {
+                user.setInstagram(extractInstagramUsername(request.getInstagram()));
+            }
+            if (request.getTwitter() != null) {
+                user.setTwitter(extractTwitterUsername(request.getTwitter()));
+            }
+            if (request.getLine() != null) {
+                user.setLine(extractLineUsername(request.getLine()));
+            }
+            if (request.getTiktok() != null) {
+                user.setTiktok(extractTiktokUsername(request.getTiktok()));
+            }
+            if (request.getDiscord() != null) {
+                user.setDiscord(extractDiscordId(request.getDiscord()));
+            }
+            if (request.getProfilePicture() != null) {
+                user.setProfilePicture(request.getProfilePicture());
+            }
+            if (request.getProfileBanner() != null) {
+                user.setProfileBanner(request.getProfileBanner());
+            }
 
             User savedUser = userService.save(user);
 
+            // ... build response ...
             return ProfileResponse.builder()
                     .id(savedUser.getId())
                     .name(savedUser.getName())
@@ -91,8 +105,14 @@ public class ProfileService {
                     .profilePicture(savedUser.getProfilePicture())
                     .build();
 
-        } catch (Exception e) {
+        } catch (ResourceNotFoundException | InvalidCredentialsException e) {
+            // Catch specific exceptions but throw the generic one expected by tests
             throw new InvalidCredentialsException("Invalid or expired token");
+        } catch (Exception e) { // Catch broader exceptions like JWT parsing errors
+            // Log the original exception e for debugging purposes
+            // logger.error("Error updating profile for user {}: {}", userId,
+            // e.getMessage(), e);
+            throw new InvalidCredentialsException("Invalid or expired token"); // Generic message
         }
     }
 
@@ -100,30 +120,26 @@ public class ProfileService {
         List<User> users = userService.findAllUsers();
 
         return users.stream()
-            .map(user -> UserPostResponse.builder()
-                .id(user.getId())
-                .name(user.getName())
-                .profilePicture(user.getProfilePicture())
-                .profileBanner(user.getProfileBanner())
-                .build())
-            .collect(Collectors.toList());
+                .map(user -> UserPostResponse.builder()
+                        .id(user.getId())
+                        .name(user.getName())
+                        .profilePicture(user.getProfilePicture())
+                        .profileBanner(user.getProfileBanner())
+                        .build())
+                .toList();
     }
-
 
     private String extractInstagramUsername(String input) {
         if (input == null || input.trim().isEmpty()) {
             return null;
         }
-
-        // Pattern to match instagram.com/username or instagram.com/@username
-        Pattern pattern = Pattern.compile("instagram\\.com/(?:@)?(\\w+)");
+        // Corrected Regex: instagram\.com/@?([\w.]+)
+        Pattern pattern = Pattern.compile("instagram\\.com/@?([\\w.]+)"); // Removed duplicate .
         Matcher matcher = pattern.matcher(input);
 
         if (matcher.find()) {
             return matcher.group(1);
         }
-
-        // If no URL pattern found, return the original input (assuming it's just the username)
         return input.trim();
     }
 
@@ -140,7 +156,8 @@ public class ProfileService {
             return matcher.group(1);
         }
 
-        // If no URL pattern found, return the original input (assuming it's just the username)
+        // If no URL pattern found, return the original input (assuming it's just the
+        // username)
         return input.trim();
     }
 
@@ -157,16 +174,13 @@ public class ProfileService {
         if (input == null || input.trim().isEmpty()) {
             return null;
         }
-
-        // Pattern to match tiktok.com/@username or tiktok.com/username
-        Pattern pattern = Pattern.compile("tiktok\\.com/(?:@)?(\\w+)");
+        // Corrected Regex: tiktok\.com/@?([\w.]+)
+        Pattern pattern = Pattern.compile("tiktok\\.com/@?([\\w.]+)"); // Removed duplicate .
         Matcher matcher = pattern.matcher(input);
 
         if (matcher.find()) {
             return matcher.group(1);
         }
-
-        // If no URL pattern found, return the original input (assuming it's just the username)
         return input.trim();
     }
 
@@ -180,16 +194,17 @@ public class ProfileService {
     }
 
     public Map<UUID, PostedByData> getUsersBatch(List<UUID> userIds) {
-        return userRepository.findAllById(userIds).stream()
-                .collect(
-                        Collectors.toMap(
-                            User::getId,
-                            user -> PostedByData.builder()
-                            .userId(user.getId())
-                            .name(user.getName())
-                            .profilePicture(user.getProfilePicture())
-                            .build()
-                        )
-                );
+        if (userIds == null || userIds.isEmpty()) {
+            return Map.of(); // Return empty map if input is empty
+        }
+        List<User> users = userRepository.findAllById(userIds);
+        return users.stream()
+                .collect(Collectors.toMap(
+                        User::getId,
+                        user -> PostedByData.builder()
+                                .userId(user.getId()) // Changed from id to userId
+                                .name(user.getName())
+                                .profilePicture(user.getProfilePicture())
+                                .build()));
     }
 }

--- a/src/main/java/com/safetypin/authentication/service/ProfileService.java
+++ b/src/main/java/com/safetypin/authentication/service/ProfileService.java
@@ -1,16 +1,5 @@
 package com.safetypin.authentication.service;
 
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.safetypin.authentication.dto.PostedByData;
 import com.safetypin.authentication.dto.ProfileResponse;
 import com.safetypin.authentication.dto.UpdateProfileRequest;
@@ -19,6 +8,16 @@ import com.safetypin.authentication.exception.InvalidCredentialsException;
 import com.safetypin.authentication.exception.ResourceNotFoundException;
 import com.safetypin.authentication.model.User;
 import com.safetypin.authentication.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 public class ProfileService {

--- a/src/test/java/com/safetypin/authentication/controller/AuthenticationControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/AuthenticationControllerTest.java
@@ -2,7 +2,6 @@ package com.safetypin.authentication.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.safetypin.authentication.dto.*;
-import com.safetypin.authentication.dto.LoginRequest;
 import com.safetypin.authentication.exception.InvalidCredentialsException;
 import com.safetypin.authentication.exception.UserAlreadyExistsException;
 import com.safetypin.authentication.model.Role;

--- a/src/test/java/com/safetypin/authentication/controller/ProfileControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/ProfileControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -327,5 +328,25 @@ class ProfileControllerTest {
         assertFalse(body.isSuccess());
         assertEquals("Error retrieving profiles: " + errorMessage, body.getMessage());
         assertNull(body.getData());
+    }
+
+    @Test
+    void getUsersBatch_Success() {
+        // Arrange
+        List<UUID> userIds = Arrays.asList(UUID.randomUUID(), UUID.randomUUID());
+        Map<UUID, PostedByData> expectedResponse = Map.of(
+                userIds.get(0), new PostedByData(userIds.get(0), "User1", "user1@example.com"),
+                userIds.get(1), new PostedByData( userIds.get(1), "User2", "user2@example.com")
+        );
+
+        when(profileService.getUsersBatch(userIds)).thenReturn(expectedResponse);
+
+        // Act
+        Map<UUID, PostedByData> response = profileController.getUsersBatch(userIds);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(expectedResponse, response);
+        assertEquals(2, response.size());
     }
 }

--- a/src/test/java/com/safetypin/authentication/controller/ProfileControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/ProfileControllerTest.java
@@ -1,10 +1,19 @@
 package com.safetypin.authentication.controller;
 
-import com.safetypin.authentication.dto.*;
-import com.safetypin.authentication.exception.InvalidCredentialsException;
-import com.safetypin.authentication.exception.ResourceNotFoundException;
-import com.safetypin.authentication.service.JwtService;
-import com.safetypin.authentication.service.ProfileService;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -13,339 +22,314 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
+import com.safetypin.authentication.dto.AuthResponse;
+import com.safetypin.authentication.dto.PostedByData;
+import com.safetypin.authentication.dto.ProfileResponse;
+import com.safetypin.authentication.dto.UpdateProfileRequest;
+import com.safetypin.authentication.dto.UserPostResponse;
+import com.safetypin.authentication.dto.UserResponse;
+import com.safetypin.authentication.exception.InvalidCredentialsException;
+import com.safetypin.authentication.exception.ResourceNotFoundException;
+import com.safetypin.authentication.service.JwtService;
+import com.safetypin.authentication.service.ProfileService;
 
 class ProfileControllerTest {
 
-    @Mock
-    private ProfileService profileService;
-    
-    @Mock
-    private JwtService jwtService;
+        @Mock
+        private ProfileService profileService;
 
-    @InjectMocks
-    private ProfileController profileController;
+        @Mock
+        private JwtService jwtService;
 
-    private UUID testUserId;
-    private ProfileResponse testProfileResponse;
-    private UpdateProfileRequest testUpdateRequest;
-    private String testAuthHeader;
-    private String testToken;
-    private List<UserPostResponse> testAllProfiles;
+        @InjectMocks
+        private ProfileController profileController;
 
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        testUserId = UUID.randomUUID();
-        testToken = "test-token";
-        testAuthHeader = "Bearer " + testToken;
+        private UUID testUserId;
+        private ProfileResponse testProfileResponse;
+        private UpdateProfileRequest testUpdateRequest;
+        private String testAuthHeader;
+        private String testToken;
+        private List<UserPostResponse> testAllProfiles;
 
-        // Set up test user response from JWT
-        UserResponse testUserResponse = UserResponse.builder()
-                .id(testUserId)
-                .name("testuser")
-                .email("test@example.com")
-                .build();
+        @BeforeEach
+        void setUp() {
+                MockitoAnnotations.openMocks(this);
+                testUserId = UUID.randomUUID();
+                testToken = "test-token";
+                testAuthHeader = "Bearer " + testToken;
 
-        // Set up test profile response
-        testProfileResponse = ProfileResponse.builder()
-                .id(testUserId)
-                .role("USER")
-                .isVerified(true)
-                .instagram("testuser")
-                .twitter("testuser")
-                .line("testuser")
-                .tiktok("testuser")
-                .discord("testuser#1234")
-                .build();
+                // Set up test user response from JWT
+                UserResponse testUserResponse = UserResponse.builder()
+                                .id(testUserId)
+                                .name("testuser")
+                                .email("test@example.com")
+                                .build();
 
-        // Set up test update request - using setters instead of builder
-        testUpdateRequest = new UpdateProfileRequest();
-        testUpdateRequest.setInstagram("newuser");
-        testUpdateRequest.setTwitter("newuser");
-        testUpdateRequest.setLine("newuser");
-        testUpdateRequest.setTiktok("newuser");
-        testUpdateRequest.setDiscord("newuser#5678");
-        testUpdateRequest.setProfilePicture("https://example.com/profile.jpg");
-        testUpdateRequest.setProfileBanner("https://example.com/banner.jpg");
-        
-        // Set up test profiles list
-        UserPostResponse profile1 = UserPostResponse.builder()
-                .id(testUserId)
-                .name("testuser")
-                .profilePicture("https://example.com/profile1.jpg")
-                .profileBanner("https://example.com/banner1.jpg")
-                .build();
-        
-        UserPostResponse profile2 = UserPostResponse.builder()
-                .id(UUID.randomUUID())
-                .name("otheruser")
-                .profilePicture("https://example.com/profile2.jpg")
-                .profileBanner("https://example.com/banner2.jpg")
-                .build();
-        
-        testAllProfiles = Arrays.asList(profile1, profile2);
-        
-        // Configure JWT service mock
-        when(jwtService.getUserFromJwtToken(testToken)).thenReturn(testUserResponse);
-    }
+                // Set up test profile response
+                testProfileResponse = ProfileResponse.builder()
+                                .id(testUserId)
+                                .role("USER")
+                                .isVerified(true)
+                                .instagram("testuser")
+                                .twitter("testuser")
+                                .line("testuser")
+                                .tiktok("testuser")
+                                .discord("testuser#1234")
+                                .build();
 
-    // GET PROFILE TESTS
+                // Set up test update request - using setters instead of builder
+                testUpdateRequest = new UpdateProfileRequest();
+                testUpdateRequest.setInstagram("newuser");
+                testUpdateRequest.setTwitter("newuser");
+                testUpdateRequest.setLine("newuser");
+                testUpdateRequest.setTiktok("newuser");
+                testUpdateRequest.setDiscord("newuser#5678");
+                testUpdateRequest.setProfilePicture("https://example.com/profile.jpg");
+                testUpdateRequest.setProfileBanner("https://example.com/banner.jpg");
 
-    @Test
-    void getProfile_Success() {
-        // Arrange
-        when(profileService.getProfile(testUserId)).thenReturn(testProfileResponse);
+                // Set up test profiles list
+                UserPostResponse profile1 = UserPostResponse.builder()
+                                .id(testUserId)
+                                .name("testuser")
+                                .profilePicture("https://example.com/profile1.jpg")
+                                .profileBanner("https://example.com/banner1.jpg")
+                                .build();
 
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId);
+                UserPostResponse profile2 = UserPostResponse.builder()
+                                .id(UUID.randomUUID())
+                                .name("otheruser")
+                                .profilePicture("https://example.com/profile2.jpg")
+                                .profileBanner("https://example.com/banner2.jpg")
+                                .build();
 
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertTrue(body.isSuccess());
-        assertEquals("Profile retrieved successfully", body.getMessage());
-        assertEquals(testProfileResponse, body.getData());
-    }
+                testAllProfiles = Arrays.asList(profile1, profile2);
 
-    @Test
-    void getProfile_NotFound() {
-        // Arrange
-        when(profileService.getProfile(testUserId))
-                .thenThrow(new ResourceNotFoundException("User not found with id " + testUserId));
+                // Configure JWT service mock
+                when(jwtService.getUserFromJwtToken(testToken)).thenReturn(testUserResponse);
+        }
 
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId);
+        // GET PROFILE TESTS
 
-        // Assert
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals("User not found with id " + testUserId, body.getMessage());
-        assertNull(body.getData());
-    }
+        @Test
+        void getProfile_Success() {
+                // Arrange
+                when(profileService.getProfile(testUserId)).thenReturn(testProfileResponse);
 
-    @Test
-    void getProfile_InternalServerError() {
-        // Arrange
-        String errorMessage = "Database connection error";
-        when(profileService.getProfile(testUserId))
-                .thenThrow(new RuntimeException(errorMessage));
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId);
 
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId);
+                // Assert
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertTrue(body.isSuccess());
+                assertEquals("Profile retrieved successfully", body.getMessage());
+                assertEquals(testProfileResponse, body.getData());
+        }
 
-        // Assert
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals("Error retrieving profile: " + errorMessage, body.getMessage());
-        assertNull(body.getData());
-    }
-    
-    // GET MY PROFILE TESTS
-    
-    @Test
-    void getMyProfile_Success() {
-        // Arrange
-        when(profileService.getProfile(testUserId)).thenReturn(testProfileResponse);
-        
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
-        
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertTrue(body.isSuccess());
-        assertEquals("Profile retrieved successfully", body.getMessage());
-        assertEquals(testProfileResponse, body.getData());
-    }
-    
-    @Test
-    void getMyProfile_NotFound() {
-        // Arrange
-        when(profileService.getProfile(testUserId))
-                .thenThrow(new ResourceNotFoundException("User not found with id " + testUserId));
-        
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
-        
-        // Assert
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals("User not found with id " + testUserId, body.getMessage());
-        assertNull(body.getData());
-    }
-    
-    @Test
-    void getMyProfile_InternalServerError() {
-        // Arrange
-        String errorMessage = "Database connection error";
-        when(profileService.getProfile(testUserId))
-                .thenThrow(new RuntimeException(errorMessage));
-        
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
-        
-        // Assert
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals("Error retrieving profile: " + errorMessage, body.getMessage());
-        assertNull(body.getData());
-    }
+        @Test
+        void getProfile_NotFound() {
+                // Arrange
+                when(profileService.getProfile(testUserId))
+                                .thenThrow(new ResourceNotFoundException("User not found with id " + testUserId));
 
-    // UPDATE MY PROFILE TESTS
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId);
 
-    @Test
-    void updateMyProfile_Success() {
-        // Arrange
-        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
-                .thenReturn(testProfileResponse);
+                // Assert
+                assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals("User not found with id " + testUserId, body.getMessage());
+                assertNull(body.getData());
+        }
 
-        // Act
-        ResponseEntity<AuthResponse> response =
-                profileController.updateMyProfile(testUpdateRequest, testAuthHeader);
+        @Test
+        void getProfile_InternalServerError() {
+                // Arrange
+                String errorMessage = "Database connection error";
+                when(profileService.getProfile(testUserId))
+                                .thenThrow(new RuntimeException(errorMessage));
 
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertTrue(body.isSuccess());
-        assertEquals("Profile updated successfully", body.getMessage());
-        assertEquals(testProfileResponse, body.getData());
-    }
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId);
 
-    @Test
-    void updateMyProfile_Unauthorized() {
-        // Arrange
-        String errorMessage = "You are not authorized to update this profile";
-        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
-                .thenThrow(new InvalidCredentialsException(errorMessage));
+                // Assert
+                assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals("Error retrieving profile: " + errorMessage, body.getMessage());
+                assertNull(body.getData());
+        }
 
-        // Act
-        ResponseEntity<AuthResponse> response =
-                profileController.updateMyProfile(testUpdateRequest, testAuthHeader);
+        // GET MY PROFILE TESTS
 
-        // Assert
-        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals(errorMessage, body.getMessage());
-        assertNull(body.getData());
-    }
+        @Test
+        void getMyProfile_Success() {
+                // Arrange
+                when(profileService.getProfile(testUserId)).thenReturn(testProfileResponse);
 
-    @Test
-    void updateMyProfile_NotFound() {
-        // Arrange
-        String errorMessage = "User not found with id " + testUserId;
-        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
-                .thenThrow(new ResourceNotFoundException(errorMessage));
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
 
-        // Act
-        ResponseEntity<AuthResponse> response =
-                profileController.updateMyProfile(testUpdateRequest, testAuthHeader);
+                // Assert
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertTrue(body.isSuccess());
+                assertEquals("Profile retrieved successfully", body.getMessage());
+                assertEquals(testProfileResponse, body.getData());
+        }
 
-        // Assert
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals(errorMessage, body.getMessage());
-        assertNull(body.getData());
-    }
+        @Test
+        void getMyProfile_NotFound() {
+                // Arrange
+                when(profileService.getProfile(testUserId))
+                                .thenThrow(new ResourceNotFoundException("User not found with id " + testUserId));
 
-    @Test
-    void updateMyProfile_InternalServerError() {
-        // Arrange
-        String errorMessage = "Database update failed";
-        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
-                .thenThrow(new RuntimeException(errorMessage));
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
 
-        // Act
-        ResponseEntity<AuthResponse> response =
-                profileController.updateMyProfile(testUpdateRequest, testAuthHeader);
+                // Assert
+                assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals("User not found with id " + testUserId, body.getMessage());
+                assertNull(body.getData());
+        }
 
-        // Assert
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals("Error updating profile: " + errorMessage, body.getMessage());
-        assertNull(body.getData());
-    }
-    
-    // GET ALL PROFILES TESTS
-    
-    @Test
-    void getAllProfiles_Success() {
-        // Arrange
-        when(profileService.getAllProfiles()).thenReturn(testAllProfiles);
-        
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getAllProfiles();
-        
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertTrue(body.isSuccess());
-        assertEquals("All profiles retrieved successfully", body.getMessage());
-        assertEquals(testAllProfiles, body.getData());
-    }
-    
-    @Test
-    void getAllProfiles_InternalServerError() {
-        // Arrange
-        String errorMessage = "Database connection error";
-        when(profileService.getAllProfiles())
-                .thenThrow(new RuntimeException(errorMessage));
-        
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getAllProfiles();
-        
-        // Assert
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals("Error retrieving profiles: " + errorMessage, body.getMessage());
-        assertNull(body.getData());
-    }
+        @Test
+        void getMyProfile_InternalServerError() {
+                // Arrange
+                String errorMessage = "Database connection error";
+                when(profileService.getProfile(testUserId))
+                                .thenThrow(new RuntimeException(errorMessage));
 
-    @Test
-    void getUsersBatch_Success() {
-        // Arrange
-        List<UUID> userIds = Arrays.asList(UUID.randomUUID(), UUID.randomUUID());
-        Map<UUID, PostedByData> expectedResponse = Map.of(
-                userIds.get(0), new PostedByData(userIds.get(0), "User1", "user1@example.com"),
-                userIds.get(1), new PostedByData( userIds.get(1), "User2", "user2@example.com")
-        );
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
 
-        when(profileService.getUsersBatch(userIds)).thenReturn(expectedResponse);
+                // Assert
+                assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals("Error retrieving profile: " + errorMessage, body.getMessage());
+                assertNull(body.getData());
+        }
 
-        // Act
-        Map<UUID, PostedByData> response = profileController.getUsersBatch(userIds);
+        // UPDATE MY PROFILE TESTS
 
-        // Assert
-        assertNotNull(response);
-        assertEquals(expectedResponse, response);
-        assertEquals(2, response.size());
-    }
+        @Test
+        void updateMyProfile_Success() {
+                // Arrange
+                when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
+                                .thenReturn(testProfileResponse);
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
+                                testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertTrue(body.isSuccess());
+                assertEquals("Profile updated successfully", body.getMessage());
+                assertEquals(testProfileResponse, body.getData());
+        }
+
+        @Test
+        void updateMyProfile_Unauthorized() {
+                // Arrange
+                String errorMessage = "You are not authorized to update this profile";
+                when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
+                                .thenThrow(new InvalidCredentialsException(errorMessage));
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
+                                testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals(errorMessage, body.getMessage());
+                assertNull(body.getData());
+        }
+
+        @Test
+        void updateMyProfile_NotFound() {
+                // Arrange
+                String errorMessage = "User not found with id " + testUserId;
+                when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
+                                .thenThrow(new ResourceNotFoundException(errorMessage));
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
+                                testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals(errorMessage, body.getMessage());
+                assertNull(body.getData());
+        }
+
+        @Test
+        void updateMyProfile_InternalServerError() {
+                // Arrange
+                String errorMessage = "Database update failed";
+                when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
+                                .thenThrow(new RuntimeException(errorMessage));
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
+                                testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals("Error updating profile: " + errorMessage, body.getMessage());
+                assertNull(body.getData());
+        }
+
+        // GET USERS BATCH TEST
+
+        @Test
+        void getUsersBatch_Success() {
+                // Arrange
+                List<UUID> userIds = Arrays.asList(UUID.randomUUID(), UUID.randomUUID());
+                // Create PostedByData instances using the builder
+                PostedByData user1Data = PostedByData.builder()
+                                .userId(userIds.get(0))
+                                .name("User1")
+                                .profilePicture("pic1.jpg")
+                                .build();
+                PostedByData user2Data = PostedByData.builder()
+                                .userId(userIds.get(1))
+                                .name("User2")
+                                .profilePicture("pic2.jpg")
+                                .build();
+                Map<UUID, PostedByData> expectedResponse = Map.of(
+                                userIds.get(0), user1Data,
+                                userIds.get(1), user2Data);
+
+                when(profileService.getUsersBatch(userIds)).thenReturn(expectedResponse);
+
+                // Act
+                Map<UUID, PostedByData> response = profileController.getUsersBatch(userIds);
+
+                // Assert
+                assertNotNull(response);
+                assertEquals(expectedResponse, response);
+                assertEquals(2, response.size());
+        }
 }

--- a/src/test/java/com/safetypin/authentication/controller/ProfileControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/ProfileControllerTest.java
@@ -1,19 +1,10 @@
 package com.safetypin.authentication.controller;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
+import com.safetypin.authentication.dto.*;
+import com.safetypin.authentication.exception.InvalidCredentialsException;
+import com.safetypin.authentication.exception.ResourceNotFoundException;
+import com.safetypin.authentication.service.JwtService;
+import com.safetypin.authentication.service.ProfileService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -22,314 +13,313 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import com.safetypin.authentication.dto.AuthResponse;
-import com.safetypin.authentication.dto.PostedByData;
-import com.safetypin.authentication.dto.ProfileResponse;
-import com.safetypin.authentication.dto.UpdateProfileRequest;
-import com.safetypin.authentication.dto.UserPostResponse;
-import com.safetypin.authentication.dto.UserResponse;
-import com.safetypin.authentication.exception.InvalidCredentialsException;
-import com.safetypin.authentication.exception.ResourceNotFoundException;
-import com.safetypin.authentication.service.JwtService;
-import com.safetypin.authentication.service.ProfileService;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 class ProfileControllerTest {
 
-        @Mock
-        private ProfileService profileService;
+    @Mock
+    private ProfileService profileService;
 
-        @Mock
-        private JwtService jwtService;
+    @Mock
+    private JwtService jwtService;
 
-        @InjectMocks
-        private ProfileController profileController;
+    @InjectMocks
+    private ProfileController profileController;
 
-        private UUID testUserId;
-        private ProfileResponse testProfileResponse;
-        private UpdateProfileRequest testUpdateRequest;
-        private String testAuthHeader;
-        private String testToken;
-        private List<UserPostResponse> testAllProfiles;
+    private UUID testUserId;
+    private ProfileResponse testProfileResponse;
+    private UpdateProfileRequest testUpdateRequest;
+    private String testAuthHeader;
+    private String testToken;
+    private List<UserPostResponse> testAllProfiles;
 
-        @BeforeEach
-        void setUp() {
-                MockitoAnnotations.openMocks(this);
-                testUserId = UUID.randomUUID();
-                testToken = "test-token";
-                testAuthHeader = "Bearer " + testToken;
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        testUserId = UUID.randomUUID();
+        testToken = "test-token";
+        testAuthHeader = "Bearer " + testToken;
 
-                // Set up test user response from JWT
-                UserResponse testUserResponse = UserResponse.builder()
-                                .id(testUserId)
-                                .name("testuser")
-                                .email("test@example.com")
-                                .build();
+        // Set up test user response from JWT
+        UserResponse testUserResponse = UserResponse.builder()
+                .id(testUserId)
+                .name("testuser")
+                .email("test@example.com")
+                .build();
 
-                // Set up test profile response
-                testProfileResponse = ProfileResponse.builder()
-                                .id(testUserId)
-                                .role("USER")
-                                .isVerified(true)
-                                .instagram("testuser")
-                                .twitter("testuser")
-                                .line("testuser")
-                                .tiktok("testuser")
-                                .discord("testuser#1234")
-                                .build();
+        // Set up test profile response
+        testProfileResponse = ProfileResponse.builder()
+                .id(testUserId)
+                .role("USER")
+                .isVerified(true)
+                .instagram("testuser")
+                .twitter("testuser")
+                .line("testuser")
+                .tiktok("testuser")
+                .discord("testuser#1234")
+                .build();
 
-                // Set up test update request - using setters instead of builder
-                testUpdateRequest = new UpdateProfileRequest();
-                testUpdateRequest.setInstagram("newuser");
-                testUpdateRequest.setTwitter("newuser");
-                testUpdateRequest.setLine("newuser");
-                testUpdateRequest.setTiktok("newuser");
-                testUpdateRequest.setDiscord("newuser#5678");
-                testUpdateRequest.setProfilePicture("https://example.com/profile.jpg");
-                testUpdateRequest.setProfileBanner("https://example.com/banner.jpg");
+        // Set up test update request - using setters instead of builder
+        testUpdateRequest = new UpdateProfileRequest();
+        testUpdateRequest.setInstagram("newuser");
+        testUpdateRequest.setTwitter("newuser");
+        testUpdateRequest.setLine("newuser");
+        testUpdateRequest.setTiktok("newuser");
+        testUpdateRequest.setDiscord("newuser#5678");
+        testUpdateRequest.setProfilePicture("https://example.com/profile.jpg");
+        testUpdateRequest.setProfileBanner("https://example.com/banner.jpg");
 
-                // Set up test profiles list
-                UserPostResponse profile1 = UserPostResponse.builder()
-                                .id(testUserId)
-                                .name("testuser")
-                                .profilePicture("https://example.com/profile1.jpg")
-                                .profileBanner("https://example.com/banner1.jpg")
-                                .build();
+        // Set up test profiles list
+        UserPostResponse profile1 = UserPostResponse.builder()
+                .id(testUserId)
+                .name("testuser")
+                .profilePicture("https://example.com/profile1.jpg")
+                .profileBanner("https://example.com/banner1.jpg")
+                .build();
 
-                UserPostResponse profile2 = UserPostResponse.builder()
-                                .id(UUID.randomUUID())
-                                .name("otheruser")
-                                .profilePicture("https://example.com/profile2.jpg")
-                                .profileBanner("https://example.com/banner2.jpg")
-                                .build();
+        UserPostResponse profile2 = UserPostResponse.builder()
+                .id(UUID.randomUUID())
+                .name("otheruser")
+                .profilePicture("https://example.com/profile2.jpg")
+                .profileBanner("https://example.com/banner2.jpg")
+                .build();
 
-                testAllProfiles = Arrays.asList(profile1, profile2);
+        testAllProfiles = Arrays.asList(profile1, profile2);
 
-                // Configure JWT service mock
-                when(jwtService.getUserFromJwtToken(testToken)).thenReturn(testUserResponse);
-        }
+        // Configure JWT service mock
+        when(jwtService.getUserFromJwtToken(testToken)).thenReturn(testUserResponse);
+    }
 
-        // GET PROFILE TESTS
+    // GET PROFILE TESTS
 
-        @Test
-        void getProfile_Success() {
-                // Arrange
-                when(profileService.getProfile(testUserId)).thenReturn(testProfileResponse);
+    @Test
+    void getProfile_Success() {
+        // Arrange
+        when(profileService.getProfile(testUserId)).thenReturn(testProfileResponse);
 
-                // Act
-                ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId);
+        // Act
+        ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId);
 
-                // Assert
-                assertEquals(HttpStatus.OK, response.getStatusCode());
-                AuthResponse body = response.getBody();
-                assertNotNull(body);
-                assertTrue(body.isSuccess());
-                assertEquals("Profile retrieved successfully", body.getMessage());
-                assertEquals(testProfileResponse, body.getData());
-        }
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        AuthResponse body = response.getBody();
+        assertNotNull(body);
+        assertTrue(body.isSuccess());
+        assertEquals("Profile retrieved successfully", body.getMessage());
+        assertEquals(testProfileResponse, body.getData());
+    }
 
-        @Test
-        void getProfile_NotFound() {
-                // Arrange
-                when(profileService.getProfile(testUserId))
-                                .thenThrow(new ResourceNotFoundException("User not found with id " + testUserId));
+    @Test
+    void getProfile_NotFound() {
+        // Arrange
+        when(profileService.getProfile(testUserId))
+                .thenThrow(new ResourceNotFoundException("User not found with id " + testUserId));
 
-                // Act
-                ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId);
+        // Act
+        ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId);
 
-                // Assert
-                assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-                AuthResponse body = response.getBody();
-                assertNotNull(body);
-                assertFalse(body.isSuccess());
-                assertEquals("User not found with id " + testUserId, body.getMessage());
-                assertNull(body.getData());
-        }
+        // Assert
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        AuthResponse body = response.getBody();
+        assertNotNull(body);
+        assertFalse(body.isSuccess());
+        assertEquals("User not found with id " + testUserId, body.getMessage());
+        assertNull(body.getData());
+    }
 
-        @Test
-        void getProfile_InternalServerError() {
-                // Arrange
-                String errorMessage = "Database connection error";
-                when(profileService.getProfile(testUserId))
-                                .thenThrow(new RuntimeException(errorMessage));
+    @Test
+    void getProfile_InternalServerError() {
+        // Arrange
+        String errorMessage = "Database connection error";
+        when(profileService.getProfile(testUserId))
+                .thenThrow(new RuntimeException(errorMessage));
 
-                // Act
-                ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId);
+        // Act
+        ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId);
 
-                // Assert
-                assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-                AuthResponse body = response.getBody();
-                assertNotNull(body);
-                assertFalse(body.isSuccess());
-                assertEquals("Error retrieving profile: " + errorMessage, body.getMessage());
-                assertNull(body.getData());
-        }
+        // Assert
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        AuthResponse body = response.getBody();
+        assertNotNull(body);
+        assertFalse(body.isSuccess());
+        assertEquals("Error retrieving profile: " + errorMessage, body.getMessage());
+        assertNull(body.getData());
+    }
 
-        // GET MY PROFILE TESTS
+    // GET MY PROFILE TESTS
 
-        @Test
-        void getMyProfile_Success() {
-                // Arrange
-                when(profileService.getProfile(testUserId)).thenReturn(testProfileResponse);
+    @Test
+    void getMyProfile_Success() {
+        // Arrange
+        when(profileService.getProfile(testUserId)).thenReturn(testProfileResponse);
 
-                // Act
-                ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
+        // Act
+        ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
 
-                // Assert
-                assertEquals(HttpStatus.OK, response.getStatusCode());
-                AuthResponse body = response.getBody();
-                assertNotNull(body);
-                assertTrue(body.isSuccess());
-                assertEquals("Profile retrieved successfully", body.getMessage());
-                assertEquals(testProfileResponse, body.getData());
-        }
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        AuthResponse body = response.getBody();
+        assertNotNull(body);
+        assertTrue(body.isSuccess());
+        assertEquals("Profile retrieved successfully", body.getMessage());
+        assertEquals(testProfileResponse, body.getData());
+    }
 
-        @Test
-        void getMyProfile_NotFound() {
-                // Arrange
-                when(profileService.getProfile(testUserId))
-                                .thenThrow(new ResourceNotFoundException("User not found with id " + testUserId));
+    @Test
+    void getMyProfile_NotFound() {
+        // Arrange
+        when(profileService.getProfile(testUserId))
+                .thenThrow(new ResourceNotFoundException("User not found with id " + testUserId));
 
-                // Act
-                ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
+        // Act
+        ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
 
-                // Assert
-                assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-                AuthResponse body = response.getBody();
-                assertNotNull(body);
-                assertFalse(body.isSuccess());
-                assertEquals("User not found with id " + testUserId, body.getMessage());
-                assertNull(body.getData());
-        }
+        // Assert
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        AuthResponse body = response.getBody();
+        assertNotNull(body);
+        assertFalse(body.isSuccess());
+        assertEquals("User not found with id " + testUserId, body.getMessage());
+        assertNull(body.getData());
+    }
 
-        @Test
-        void getMyProfile_InternalServerError() {
-                // Arrange
-                String errorMessage = "Database connection error";
-                when(profileService.getProfile(testUserId))
-                                .thenThrow(new RuntimeException(errorMessage));
+    @Test
+    void getMyProfile_InternalServerError() {
+        // Arrange
+        String errorMessage = "Database connection error";
+        when(profileService.getProfile(testUserId))
+                .thenThrow(new RuntimeException(errorMessage));
 
-                // Act
-                ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
+        // Act
+        ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
 
-                // Assert
-                assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-                AuthResponse body = response.getBody();
-                assertNotNull(body);
-                assertFalse(body.isSuccess());
-                assertEquals("Error retrieving profile: " + errorMessage, body.getMessage());
-                assertNull(body.getData());
-        }
+        // Assert
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        AuthResponse body = response.getBody();
+        assertNotNull(body);
+        assertFalse(body.isSuccess());
+        assertEquals("Error retrieving profile: " + errorMessage, body.getMessage());
+        assertNull(body.getData());
+    }
 
-        // UPDATE MY PROFILE TESTS
+    // UPDATE MY PROFILE TESTS
 
-        @Test
-        void updateMyProfile_Success() {
-                // Arrange
-                when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
-                                .thenReturn(testProfileResponse);
+    @Test
+    void updateMyProfile_Success() {
+        // Arrange
+        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
+                .thenReturn(testProfileResponse);
 
-                // Act
-                ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
-                                testAuthHeader);
+        // Act
+        ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
+                testAuthHeader);
 
-                // Assert
-                assertEquals(HttpStatus.OK, response.getStatusCode());
-                AuthResponse body = response.getBody();
-                assertNotNull(body);
-                assertTrue(body.isSuccess());
-                assertEquals("Profile updated successfully", body.getMessage());
-                assertEquals(testProfileResponse, body.getData());
-        }
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        AuthResponse body = response.getBody();
+        assertNotNull(body);
+        assertTrue(body.isSuccess());
+        assertEquals("Profile updated successfully", body.getMessage());
+        assertEquals(testProfileResponse, body.getData());
+    }
 
-        @Test
-        void updateMyProfile_Unauthorized() {
-                // Arrange
-                String errorMessage = "You are not authorized to update this profile";
-                when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
-                                .thenThrow(new InvalidCredentialsException(errorMessage));
+    @Test
+    void updateMyProfile_Unauthorized() {
+        // Arrange
+        String errorMessage = "You are not authorized to update this profile";
+        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
+                .thenThrow(new InvalidCredentialsException(errorMessage));
 
-                // Act
-                ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
-                                testAuthHeader);
+        // Act
+        ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
+                testAuthHeader);
 
-                // Assert
-                assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
-                AuthResponse body = response.getBody();
-                assertNotNull(body);
-                assertFalse(body.isSuccess());
-                assertEquals(errorMessage, body.getMessage());
-                assertNull(body.getData());
-        }
+        // Assert
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        AuthResponse body = response.getBody();
+        assertNotNull(body);
+        assertFalse(body.isSuccess());
+        assertEquals(errorMessage, body.getMessage());
+        assertNull(body.getData());
+    }
 
-        @Test
-        void updateMyProfile_NotFound() {
-                // Arrange
-                String errorMessage = "User not found with id " + testUserId;
-                when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
-                                .thenThrow(new ResourceNotFoundException(errorMessage));
+    @Test
+    void updateMyProfile_NotFound() {
+        // Arrange
+        String errorMessage = "User not found with id " + testUserId;
+        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
+                .thenThrow(new ResourceNotFoundException(errorMessage));
 
-                // Act
-                ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
-                                testAuthHeader);
+        // Act
+        ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
+                testAuthHeader);
 
-                // Assert
-                assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-                AuthResponse body = response.getBody();
-                assertNotNull(body);
-                assertFalse(body.isSuccess());
-                assertEquals(errorMessage, body.getMessage());
-                assertNull(body.getData());
-        }
+        // Assert
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        AuthResponse body = response.getBody();
+        assertNotNull(body);
+        assertFalse(body.isSuccess());
+        assertEquals(errorMessage, body.getMessage());
+        assertNull(body.getData());
+    }
 
-        @Test
-        void updateMyProfile_InternalServerError() {
-                // Arrange
-                String errorMessage = "Database update failed";
-                when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
-                                .thenThrow(new RuntimeException(errorMessage));
+    @Test
+    void updateMyProfile_InternalServerError() {
+        // Arrange
+        String errorMessage = "Database update failed";
+        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
+                .thenThrow(new RuntimeException(errorMessage));
 
-                // Act
-                ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
-                                testAuthHeader);
+        // Act
+        ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
+                testAuthHeader);
 
-                // Assert
-                assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-                AuthResponse body = response.getBody();
-                assertNotNull(body);
-                assertFalse(body.isSuccess());
-                assertEquals("Error updating profile: " + errorMessage, body.getMessage());
-                assertNull(body.getData());
-        }
+        // Assert
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        AuthResponse body = response.getBody();
+        assertNotNull(body);
+        assertFalse(body.isSuccess());
+        assertEquals("Error updating profile: " + errorMessage, body.getMessage());
+        assertNull(body.getData());
+    }
 
-        // GET USERS BATCH TEST
+    // GET USERS BATCH TEST
 
-        @Test
-        void getUsersBatch_Success() {
-                // Arrange
-                List<UUID> userIds = Arrays.asList(UUID.randomUUID(), UUID.randomUUID());
-                // Create PostedByData instances using the builder
-                PostedByData user1Data = PostedByData.builder()
-                                .userId(userIds.get(0))
-                                .name("User1")
-                                .profilePicture("pic1.jpg")
-                                .build();
-                PostedByData user2Data = PostedByData.builder()
-                                .userId(userIds.get(1))
-                                .name("User2")
-                                .profilePicture("pic2.jpg")
-                                .build();
-                Map<UUID, PostedByData> expectedResponse = Map.of(
-                                userIds.get(0), user1Data,
-                                userIds.get(1), user2Data);
+    @Test
+    void getUsersBatch_Success() {
+        // Arrange
+        List<UUID> userIds = Arrays.asList(UUID.randomUUID(), UUID.randomUUID());
+        // Create PostedByData instances using the builder
+        PostedByData user1Data = PostedByData.builder()
+                .userId(userIds.get(0))
+                .name("User1")
+                .profilePicture("pic1.jpg")
+                .build();
+        PostedByData user2Data = PostedByData.builder()
+                .userId(userIds.get(1))
+                .name("User2")
+                .profilePicture("pic2.jpg")
+                .build();
+        Map<UUID, PostedByData> expectedResponse = Map.of(
+                userIds.get(0), user1Data,
+                userIds.get(1), user2Data);
 
-                when(profileService.getUsersBatch(userIds)).thenReturn(expectedResponse);
+        when(profileService.getUsersBatch(userIds)).thenReturn(expectedResponse);
 
-                // Act
-                Map<UUID, PostedByData> response = profileController.getUsersBatch(userIds);
+        // Act
+        Map<UUID, PostedByData> response = profileController.getUsersBatch(userIds);
 
-                // Assert
-                assertNotNull(response);
-                assertEquals(expectedResponse, response);
-                assertEquals(2, response.size());
-        }
+        // Assert
+        assertNotNull(response);
+        assertEquals(expectedResponse, response);
+        assertEquals(2, response.size());
+    }
 }

--- a/src/test/java/com/safetypin/authentication/controller/ProfileControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/ProfileControllerTest.java
@@ -39,7 +39,6 @@ class ProfileControllerTest {
     private UpdateProfileRequest testUpdateRequest;
     private String testAuthHeader;
     private String testToken;
-    private UserResponse testUserResponse;
     private List<UserPostResponse> testAllProfiles;
 
     @BeforeEach
@@ -50,7 +49,7 @@ class ProfileControllerTest {
         testAuthHeader = "Bearer " + testToken;
 
         // Set up test user response from JWT
-        testUserResponse = UserResponse.builder()
+        UserResponse testUserResponse = UserResponse.builder()
                 .id(testUserId)
                 .name("testuser")
                 .email("test@example.com")

--- a/src/test/java/com/safetypin/authentication/controller/SearchControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/SearchControllerTest.java
@@ -1,21 +1,10 @@
 package com.safetypin.authentication.controller;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
+import com.safetypin.authentication.dto.UserResponse;
+import com.safetypin.authentication.model.Role;
+import com.safetypin.authentication.model.User;
+import com.safetypin.authentication.service.ProfileService;
+import com.safetypin.authentication.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,11 +16,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import com.safetypin.authentication.dto.UserResponse;
-import com.safetypin.authentication.model.Role;
-import com.safetypin.authentication.model.User;
-import com.safetypin.authentication.service.ProfileService;
-import com.safetypin.authentication.service.UserService;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("SearchController Unit Tests")

--- a/src/test/java/com/safetypin/authentication/controller/SearchControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/SearchControllerTest.java
@@ -1,90 +1,215 @@
 package com.safetypin.authentication.controller;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.safetypin.authentication.dto.UserResponse;
 import com.safetypin.authentication.model.Role;
 import com.safetypin.authentication.model.User;
-import com.safetypin.authentication.repository.UserRepository;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
+import com.safetypin.authentication.service.ProfileService;
+import com.safetypin.authentication.service.UserService;
 
-import java.util.List;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-@ActiveProfiles("test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT) // Load full app
-@AutoConfigureMockMvc
-@TestInstance(TestInstance.Lifecycle.PER_CLASS) // Keep the same instance for DB setup
-@Transactional // Rollback after each test
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SearchController Unit Tests")
 class SearchControllerTest {
 
+    @Mock
+    private UserService userService;
 
-    @Autowired
-    private MockMvc mockMvc;
+    @Mock
+    private ProfileService profileService;
 
-    @Autowired
-    private UserRepository userRepository; // Use actual repository
+    @InjectMocks
+    private SearchController searchController;
 
-    @BeforeAll
+    private User user1;
+    private User user2;
+    private User user3;
+    private List<User> allUsers;
+    private List<User> johnUsers;
+
+    @BeforeEach
     void setUp() {
-        userRepository.deleteAll(); // Clean DB before tests
-
-        // Insert real users into the database with non-nullable fields
-        User user1 = new User();
+        user1 = new User();
+        user1.setId(UUID.randomUUID());
         user1.setName("John Doe");
         user1.setEmail("john.doe@example.com");
         user1.setRole(Role.REGISTERED_USER);
+        user1.setVerified(true);
 
-        User user2 = new User();
-        user2.setName("John Richard");
-        user2.setEmail("john.richard@example.com");
+        user2 = new User();
+        user2.setId(UUID.randomUUID());
+        user2.setName("Jane Smith");
+        user2.setEmail("jane.smith@example.com");
         user2.setRole(Role.REGISTERED_USER);
+        user2.setVerified(false);
 
-        User user3 = new User();
-        user3.setName("Koala Kom");
-        user3.setEmail("koala.kom@example.com");
-        user3.setRole(Role.REGISTERED_USER);
+        user3 = new User();
+        user3.setId(UUID.randomUUID());
+        user3.setName("John Richard");
+        user3.setEmail("john.richard@example.com");
+        user3.setRole(Role.MODERATOR); // Different role
+        user3.setVerified(true);
 
-        userRepository.saveAll(List.of(user1, user2, user3));
+        allUsers = Arrays.asList(user1, user2, user3);
+        johnUsers = Arrays.asList(user1, user3);
     }
 
-    @Test
-    void testSearchMultipleUsersByName() throws Exception {
+    @Nested
+    @DisplayName("searchUsersByName Method Tests")
+    class SearchUsersByNameTests {
 
-        mockMvc.perform(get("/api/users/search")
-                        .param("query", "john")) // Actual DB query
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.size()").value(2)) // Expect only 2 users with "John"
-                .andExpect(jsonPath("$[0].name").value("John Doe"))
-                .andExpect(jsonPath("$[1].name").value("John Richard"));
-    }
+        @Test
+        @DisplayName("Search with query 'john' returns matching users")
+        void searchUsersByName_withQuery_returnsMatchingUsers() {
+            // Arrange
+            String query = "john";
+            when(userService.findUsersByNameContaining(query)).thenReturn(johnUsers);
 
-    @Test
-    void testSearchAllUsersWhenNoQueryProvided() throws Exception {
-        mockMvc.perform(get("/api/users/search")) // No query parameter
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.size()").value(3)) // Expect all 3 users
-                .andExpect(jsonPath("$[0].name").value("John Doe"))
-                .andExpect(jsonPath("$[1].name").value("John Richard"))
-                .andExpect(jsonPath("$[2].name").value("Koala Kom"));
-    }
+            // Act
+            ResponseEntity<List<UserResponse>> response = searchController.searchUsersByName(query);
 
-    @Test
-    void testSearchAllUsersWhenEmptyQuery() throws Exception {
-        mockMvc.perform(get("/api/users/search")
-                        .param("query", "   "))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.size()").value(3)) // Expect all 3 users
-                .andExpect(jsonPath("$[0].name").value("John Doe"))
-                .andExpect(jsonPath("$[1].name").value("John Richard"))
-                .andExpect(jsonPath("$[2].name").value("Koala Kom"));
+            // Assert
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            List<UserResponse> resultUsers = response.getBody();
+            assertThat(resultUsers, hasSize(2));
+            // Assert based on UserResponse fields (assuming UserResponse has these getters)
+            assertThat(resultUsers.get(0).getId(), is(user1.getId()));
+            assertThat(resultUsers.get(0).getName(), is("John Doe"));
+            // Assuming UserResponse.getRole() returns String
+            assertThat(resultUsers.get(0).getRole(), is(Role.REGISTERED_USER.name()));
+            assertThat(resultUsers.get(0).isVerified(), is(true));
+            assertThat(resultUsers.get(1).getId(), is(user3.getId()));
+            assertThat(resultUsers.get(1).getName(), is("John Richard"));
+            // Assuming UserResponse.getRole() returns String
+            assertThat(resultUsers.get(1).getRole(), is(Role.MODERATOR.name()));
+            assertThat(resultUsers.get(1).isVerified(), is(true));
+
+            verify(userService, times(1)).findUsersByNameContaining(query);
+            verify(userService, never()).findAllUsers();
+        }
+
+        @Test
+        @DisplayName("Search with null query parameter returns all users")
+        void searchUsersByName_nullQuery_returnsAllUsers() {
+            // Arrange
+            when(userService.findAllUsers()).thenReturn(allUsers);
+
+            // Act
+            ResponseEntity<List<UserResponse>> response = searchController.searchUsersByName(null);
+
+            // Assert
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            List<UserResponse> resultUsers = response.getBody();
+            assertThat(resultUsers, hasSize(3));
+            assertThat(resultUsers.get(0).getName(), is("John Doe"));
+            assertThat(resultUsers.get(1).getName(), is("Jane Smith"));
+            assertThat(resultUsers.get(2).getName(), is("John Richard"));
+            // Optionally assert roles/verified status if needed
+            assertThat(resultUsers.get(0).getRole(), is(Role.REGISTERED_USER.name()));
+            assertThat(resultUsers.get(1).getRole(), is(Role.REGISTERED_USER.name()));
+            assertThat(resultUsers.get(2).getRole(), is(Role.MODERATOR.name()));
+
+            verify(userService, times(1)).findAllUsers();
+            verify(userService, never()).findUsersByNameContaining(anyString());
+        }
+
+        @Test
+        @DisplayName("Search with empty query parameter returns all users")
+        void searchUsersByName_emptyQuery_returnsAllUsers() {
+            // Arrange
+            String query = "";
+            when(userService.findAllUsers()).thenReturn(allUsers);
+
+            // Act
+            ResponseEntity<List<UserResponse>> response = searchController.searchUsersByName(query);
+
+            // Assert
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            List<UserResponse> resultUsers = response.getBody();
+            assertThat(resultUsers, hasSize(3));
+            assertThat(resultUsers.get(0).getName(), is("John Doe"));
+            assertThat(resultUsers.get(1).getName(), is("Jane Smith"));
+            assertThat(resultUsers.get(2).getName(), is("John Richard"));
+            assertThat(resultUsers.get(0).getRole(), is(Role.REGISTERED_USER.name()));
+            assertThat(resultUsers.get(1).getRole(), is(Role.REGISTERED_USER.name()));
+            assertThat(resultUsers.get(2).getRole(), is(Role.MODERATOR.name()));
+
+            verify(userService, times(1)).findAllUsers();
+            verify(userService, never()).findUsersByNameContaining(anyString());
+        }
+
+        @Test
+        @DisplayName("Search with whitespace query parameter returns all users")
+        void searchUsersByName_whitespaceQuery_returnsAllUsers() {
+            // Arrange
+            String query = "   ";
+            when(userService.findAllUsers()).thenReturn(allUsers);
+
+            // Act
+            ResponseEntity<List<UserResponse>> response = searchController.searchUsersByName(query);
+
+            // Assert
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            List<UserResponse> resultUsers = response.getBody();
+            assertThat(resultUsers, hasSize(3));
+            assertThat(resultUsers.get(0).getName(), is("John Doe"));
+            assertThat(resultUsers.get(1).getName(), is("Jane Smith"));
+            assertThat(resultUsers.get(2).getName(), is("John Richard"));
+            assertThat(resultUsers.get(0).getRole(), is(Role.REGISTERED_USER.name()));
+            assertThat(resultUsers.get(1).getRole(), is(Role.REGISTERED_USER.name()));
+            assertThat(resultUsers.get(2).getRole(), is(Role.MODERATOR.name()));
+
+            verify(userService, times(1)).findAllUsers();
+            verify(userService, never()).findUsersByNameContaining(anyString());
+        }
+
+        @Test
+        @DisplayName("Search with query yielding no results returns empty list")
+        void searchUsersByName_noResults_returnsEmptyList() {
+            // Arrange
+            String query = "nonexistent";
+            when(userService.findUsersByNameContaining(query)).thenReturn(Collections.emptyList());
+
+            // Act
+            ResponseEntity<List<UserResponse>> response = searchController.searchUsersByName(query);
+
+            // Assert
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertNotNull(response.getBody());
+            List<UserResponse> resultUsers = response.getBody();
+            assertThat(resultUsers, hasSize(0));
+
+            verify(userService, times(1)).findUsersByNameContaining(query);
+            verify(userService, never()).findAllUsers();
+        }
     }
 }

--- a/src/test/java/com/safetypin/authentication/controller/UserProfileBatchControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/UserProfileBatchControllerTest.java
@@ -1,0 +1,169 @@
+package com.safetypin.authentication.controller;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.safetypin.authentication.dto.PostedByData;
+import com.safetypin.authentication.service.JwtService;
+import com.safetypin.authentication.service.ProfileService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProfileController Batch Endpoint Unit Tests")
+class ProfileControllerBatchEndpointTest {
+
+    @Mock
+    private ProfileService profileService;
+
+    @Mock
+    private JwtService jwtService;
+
+    @InjectMocks
+    private ProfileController profileController;
+
+    private UUID userId1;
+    private UUID userId2;
+    private List<UUID> userIds;
+    private Map<UUID, PostedByData> postedByDataMap;
+    private PostedByData profile1;
+    private PostedByData profile2;
+
+    @BeforeEach
+    void setUp() {
+        userId1 = UUID.randomUUID();
+        userId2 = UUID.randomUUID();
+        userIds = Arrays.asList(userId1, userId2);
+
+        profile1 = PostedByData.builder()
+                .userId(userId1)
+                .name("User One")
+                .profilePicture("pic1.jpg")
+                .build();
+        profile2 = PostedByData.builder()
+                .userId(userId2)
+                .name("User Two")
+                .profilePicture("pic2.jpg")
+                .build();
+        postedByDataMap = Map.of(userId1, profile1, userId2, profile2);
+    }
+
+    @Test
+    @DisplayName("Valid request with user IDs returns corresponding profiles map")
+    void getUsersBatch_validRequest_returnsProfilesMap() {
+        // Arrange
+        when(profileService.getUsersBatch(userIds)).thenReturn(postedByDataMap);
+
+        // Act
+        Map<UUID, PostedByData> responseMap = profileController.getUsersBatch(userIds);
+
+        // Assert
+        assertNotNull(responseMap);
+        assertThat(responseMap, aMapWithSize(2));
+        assertThat(responseMap, hasEntry(is(userId1), is(profile1)));
+        assertThat(responseMap, hasEntry(is(userId2), is(profile2)));
+        assertEquals("User One", responseMap.get(userId1).getName());
+        assertEquals("pic2.jpg", responseMap.get(userId2).getProfilePicture());
+
+        // Verify the service method was called
+        verify(profileService, times(1)).getUsersBatch(userIds);
+    }
+
+    @Test
+    @DisplayName("Request with empty user ID list returns empty map from service")
+    void getUsersBatch_emptyList_returnsEmptyMap() {
+        // Arrange
+        List<UUID> emptyList = Collections.emptyList();
+        when(profileService.getUsersBatch(emptyList)).thenReturn(Collections.emptyMap());
+
+        // Act
+        Map<UUID, PostedByData> responseMap = profileController.getUsersBatch(emptyList);
+
+        // Assert
+        assertNotNull(responseMap);
+        assertThat(responseMap, aMapWithSize(0));
+
+        // Verify service method was called with the empty list
+        verify(profileService, times(1)).getUsersBatch(emptyList);
+    }
+
+    @Test
+    @DisplayName("Request with null user ID list returns empty map from service")
+    void getUsersBatch_nullList_returnsEmptyMap() {
+        // Arrange
+        when(profileService.getUsersBatch(isNull())).thenReturn(Collections.emptyMap());
+
+        // Act
+        Map<UUID, PostedByData> responseMap = profileController.getUsersBatch(null);
+
+        // Assert
+        assertNotNull(responseMap);
+        assertThat(responseMap, aMapWithSize(0));
+
+        // Verify service method was called with null
+        verify(profileService, times(1)).getUsersBatch(isNull());
+    }
+
+    @Test
+    @DisplayName("Service returns partial results (some IDs not found)")
+    void getUsersBatch_partialResults_returnsPartialMap() {
+        // Arrange
+        UUID userId3 = UUID.randomUUID();
+        List<UUID> requestedIds = Arrays.asList(userId1, userId3);
+
+        // Simulate service returning only profile for user1 in a map
+        Map<UUID, PostedByData> partialMap = Map.of(userId1, profile1);
+        when(profileService.getUsersBatch(requestedIds)).thenReturn(partialMap);
+
+        // Act
+        Map<UUID, PostedByData> responseMap = profileController.getUsersBatch(requestedIds);
+
+        // Assert
+        assertNotNull(responseMap);
+        assertThat(responseMap, aMapWithSize(1));
+        assertThat(responseMap, hasEntry(is(userId1), is(profile1)));
+        assertThat(responseMap, not(hasKey(userId3)));
+
+        // Verify the service method was called
+        verify(profileService, times(1)).getUsersBatch(requestedIds);
+    }
+
+    @Test
+    @DisplayName("Service returns empty map (no IDs found)")
+    void getUsersBatch_noResultsFromService_returnsEmptyMap() {
+        // Arrange
+        when(profileService.getUsersBatch(userIds)).thenReturn(Collections.emptyMap());
+
+        // Act
+        Map<UUID, PostedByData> responseMap = profileController.getUsersBatch(userIds);
+
+        // Assert
+        assertNotNull(responseMap);
+        assertThat(responseMap, aMapWithSize(0));
+
+        // Verify the service method was called
+        verify(profileService, times(1)).getUsersBatch(userIds);
+    }
+}

--- a/src/test/java/com/safetypin/authentication/controller/UserProfileBatchControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/UserProfileBatchControllerTest.java
@@ -1,24 +1,8 @@
 package com.safetypin.authentication.controller;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.aMapWithSize;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
+import com.safetypin.authentication.dto.PostedByData;
+import com.safetypin.authentication.service.JwtService;
+import com.safetypin.authentication.service.ProfileService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,9 +11,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.safetypin.authentication.dto.PostedByData;
-import com.safetypin.authentication.service.JwtService;
-import com.safetypin.authentication.service.ProfileService;
+import java.util.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ProfileController Batch Endpoint Unit Tests")

--- a/src/test/java/com/safetypin/authentication/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/safetypin/authentication/repository/RefreshTokenRepositoryTest.java
@@ -9,8 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/safetypin/authentication/service/EmailServiceTest.java
+++ b/src/test/java/com/safetypin/authentication/service/EmailServiceTest.java
@@ -1,13 +1,11 @@
 package com.safetypin.authentication.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.store.FolderException;
+import com.icegreen.greenmail.util.ServerSetup;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,13 +15,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import com.icegreen.greenmail.configuration.GreenMailConfiguration;
-import com.icegreen.greenmail.junit5.GreenMailExtension;
-import com.icegreen.greenmail.store.FolderException;
-import com.icegreen.greenmail.util.ServerSetup;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
+import static org.junit.jupiter.api.Assertions.*;
 
 // Email integration test
 @SpringBootTest

--- a/src/test/java/com/safetypin/authentication/service/EmailServiceTest.java
+++ b/src/test/java/com/safetypin/authentication/service/EmailServiceTest.java
@@ -1,31 +1,34 @@
 package com.safetypin.authentication.service;
 
-import com.icegreen.greenmail.configuration.GreenMailConfiguration;
-import com.icegreen.greenmail.junit5.GreenMailExtension;
-import com.icegreen.greenmail.store.FolderException;
-import com.icegreen.greenmail.util.ServerSetup;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.store.FolderException;
+import com.icegreen.greenmail.util.ServerSetup;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 
 // Email integration test
 @SpringBootTest
 @ActiveProfiles("test")
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 class EmailServiceTest {
     @RegisterExtension
     static GreenMailExtension greenMail = new GreenMailExtension(

--- a/src/test/java/com/safetypin/authentication/service/GoogleAuthServiceTest.java
+++ b/src/test/java/com/safetypin/authentication/service/GoogleAuthServiceTest.java
@@ -16,7 +16,6 @@ import com.safetypin.authentication.exception.InvalidCredentialsException;
 import com.safetypin.authentication.exception.UserAlreadyExistsException;
 import com.safetypin.authentication.model.RefreshToken;
 import com.safetypin.authentication.model.User;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,41 +53,41 @@ class GoogleAuthServiceTest {
     private final String testGoogleClientId = "test-client-id";
     private final String testIdToken = "test-id-token";
     private final String testRefreshToken = "test-refresh-token";
-    
+
     @Mock
     private UserService userService;
-    
+
     @Mock
     private JwtService jwtService;
-    
+
     @Mock
     private RefreshTokenService refreshTokenService;
-    
+
     @Mock
     private GoogleIdToken idToken;
-    
+
     @Mock
     private GoogleIdToken.Payload payload;
-    
+
     @Mock
     private GoogleIdTokenVerifier verifier;
-    
+
     @Mock
     private GoogleAuthorizationCodeTokenRequest tokenRequest;
-    
+
     @Mock
     private GoogleTokenResponse tokenResponse;
-    
+
     @Spy
     @InjectMocks
     private GoogleAuthService googleAuthService;
-    
+
     @Mock
     private Appender<ILoggingEvent> mockAppender;
-    
+
     @Captor
     private ArgumentCaptor<ILoggingEvent> loggingEventCaptor;
-    
+
     private GoogleAuthDTO googleAuthDTO;
     private UUID testUserId;
 
@@ -161,7 +160,7 @@ class GoogleAuthServiceTest {
 
         // Mock JWT generation
         when(jwtService.generateToken(any(UUID.class))).thenReturn("test-jwt-token");
-        
+
         // Mock refresh token creation
         RefreshToken mockRefreshToken = new RefreshToken();
         mockRefreshToken.setToken(testRefreshToken);
@@ -193,7 +192,7 @@ class GoogleAuthServiceTest {
 
         // Mock JWT generation
         when(jwtService.generateToken(any(UUID.class))).thenReturn("test-jwt-token");
-        
+
         // Mock refresh token creation
         RefreshToken mockRefreshToken = new RefreshToken();
         mockRefreshToken.setToken(testRefreshToken);
@@ -752,7 +751,7 @@ class GoogleAuthServiceTest {
 
         // Mock JWT generation
         when(jwtService.generateToken(any(UUID.class))).thenReturn("test-jwt-token");
-        
+
         // Mock refresh token creation
         RefreshToken mockRefreshToken = new RefreshToken();
         mockRefreshToken.setToken(testRefreshToken);
@@ -813,8 +812,8 @@ class GoogleAuthServiceTest {
 
         // Execute and verify
         IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> googleAuthService.authenticate(googleAuthDTO)
+                IllegalArgumentException.class,
+                () -> googleAuthService.authenticate(googleAuthDTO)
         );
 
         assertEquals("Permission denied: Birthdate not provided", exception.getMessage());
@@ -957,31 +956,31 @@ class GoogleAuthServiceTest {
     void testOpenDirectConnection_Success() throws IOException {
         // Create a test URL
         URL testUrl = URI.create("https://example.com").toURL();
-        
+
         // Create a subclass that overrides the method to test
         class TestService extends GoogleAuthService {
             public TestService() {
                 super(userService, jwtService, refreshTokenService);
             }
-            
+
             @Override
             protected HttpURLConnection openDirectConnection(URL url) throws IOException {
                 // Verify the URL is what we expect
                 assertEquals(testUrl, url);
-                
+
                 // Return a mock connection
                 return mock(HttpURLConnection.class);
             }
         }
-        
+
         // Create the test service
         TestService service = new TestService();
-        
+
         // Call the method
         HttpURLConnection result = service.openDirectConnection(testUrl);
-        
+
         // Verify the result is a mock
-        assertTrue(result instanceof HttpURLConnection);
+        assertInstanceOf(HttpURLConnection.class, result);
         verify(result, never()).connect(); // Never actually connects
     }
 
@@ -989,24 +988,24 @@ class GoogleAuthServiceTest {
     void testOpenDirectConnection_ThrowsIOException() throws IOException {
         // Create a test URL
         URL testUrl = URI.create("https://example.com").toURL();
-        
+
         // Create a subclass that overrides the method to throw an exception
         class TestService extends GoogleAuthService {
             public TestService() {
                 super(userService, jwtService, refreshTokenService);
             }
-            
+
             @Override
             protected HttpURLConnection openDirectConnection(URL url) throws IOException {
                 throw new IOException("Test connection error");
             }
         }
-        
+
         // Create the test service
         TestService service = new TestService();
-        
+
         // Verify the exception is propagated
-        IOException exception = assertThrows(IOException.class, 
+        IOException exception = assertThrows(IOException.class,
                 () -> service.openDirectConnection(testUrl));
         assertEquals("Test connection error", exception.getMessage());
     }
@@ -1016,35 +1015,35 @@ class GoogleAuthServiceTest {
         // Create test URL and proxy
         URL testUrl = URI.create("https://example.com").toURL();
         java.net.Proxy testProxy = new java.net.Proxy(
-                java.net.Proxy.Type.HTTP, 
+                java.net.Proxy.Type.HTTP,
                 new java.net.InetSocketAddress("proxy.example.com", 8080)
         );
-        
+
         // Create a subclass that overrides the method to test
         class TestService extends GoogleAuthService {
             public TestService() {
                 super(userService, jwtService, refreshTokenService);
             }
-            
+
             @Override
             protected HttpURLConnection openProxyConnection(URL url, java.net.Proxy proxy) throws IOException {
                 // Verify the arguments are what we expect
                 assertEquals(testUrl, url);
                 assertEquals(testProxy, proxy);
-                
+
                 // Return a mock connection
                 return mock(HttpURLConnection.class);
             }
         }
-        
+
         // Create the test service
         TestService service = new TestService();
-        
+
         // Call the method
         HttpURLConnection result = service.openProxyConnection(testUrl, testProxy);
-        
+
         // Verify the result is a mock
-        assertTrue(result instanceof HttpURLConnection);
+        assertInstanceOf(HttpURLConnection.class, result);
         verify(result, never()).connect(); // Never actually connects
     }
 
@@ -1053,27 +1052,27 @@ class GoogleAuthServiceTest {
         // Create test URL and proxy
         URL testUrl = URI.create("https://example.com").toURL();
         java.net.Proxy testProxy = new java.net.Proxy(
-                java.net.Proxy.Type.HTTP, 
+                java.net.Proxy.Type.HTTP,
                 new java.net.InetSocketAddress("proxy.example.com", 8080)
         );
-        
+
         // Create a subclass that overrides the method to throw an exception
         class TestService extends GoogleAuthService {
             public TestService() {
                 super(userService, jwtService, refreshTokenService);
             }
-            
+
             @Override
             protected HttpURLConnection openProxyConnection(URL url, java.net.Proxy proxy) throws IOException {
                 throw new IOException("Test proxy connection error");
             }
         }
-        
+
         // Create the test service
         TestService service = new TestService();
-        
+
         // Verify the exception is propagated
-        IOException exception = assertThrows(IOException.class, 
+        IOException exception = assertThrows(IOException.class,
                 () -> service.openProxyConnection(testUrl, testProxy));
         assertEquals("Test proxy connection error", exception.getMessage());
     }
@@ -1083,20 +1082,20 @@ class GoogleAuthServiceTest {
         // Setup test data
         String testProxyUrl = "http://proxy.example.com:8443";
         String testResponse = "{\"birthdays\":[{\"date\":{\"year\":1990,\"month\":1,\"day\":1}}]}";
-        
+
         // Create a subclass that simulates HTTPS proxy configuration
         class TestService extends GoogleAuthService {
             public TestService() {
                 super(userService, jwtService, refreshTokenService);
             }
-            
+
             @Override
             protected String getEnv(String name) {
                 if ("HTTPS_PROXY".equals(name)) return testProxyUrl;
                 if ("HTTP_PROXY".equals(name)) return null;
                 return null;
             }
-            
+
             @Override
             protected URL createURL(String urlString) throws MalformedURLException {
                 if (urlString.equals(testProxyUrl)) {
@@ -1104,33 +1103,33 @@ class GoogleAuthServiceTest {
                 }
                 return URI.create("https://example.com").toURL();
             }
-            
+
             @Override
             protected HttpURLConnection openProxyConnection(URL url, java.net.Proxy proxy) throws IOException {
                 // Return a mock connection that will succeed
                 HttpURLConnection mockConnection = mock(HttpURLConnection.class);
                 when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
-                
+
                 // Set up the mock input stream with our test response
                 InputStream mockStream = new ByteArrayInputStream(testResponse.getBytes());
                 when(mockConnection.getInputStream()).thenReturn(mockStream);
-                
+
                 return mockConnection;
             }
-            
+
             @Override
             protected HttpURLConnection openDirectConnection(URL url) {
                 fail("Should not use direct connection when proxy is configured");
                 return null;
             }
         }
-        
+
         // Create the test service
         TestService service = new TestService();
-        
+
         // Execute
         String result = service.fetchUserData("test-token");
-        
+
         // Verify
         assertEquals(testResponse, result);
     }
@@ -1140,20 +1139,20 @@ class GoogleAuthServiceTest {
         // Setup test data
         String testHttpProxyUrl = "http://http-proxy.example.com:8080";
         String testResponse = "{\"birthdays\":[{\"date\":{\"year\":1990,\"month\":1,\"day\":1}}]}";
-        
+
         // Create a subclass that simulates HTTP proxy configuration
         class TestService extends GoogleAuthService {
             public TestService() {
                 super(userService, jwtService, refreshTokenService);
             }
-            
+
             @Override
             protected String getEnv(String name) {
                 if ("HTTPS_PROXY".equals(name)) return null;
                 if ("HTTP_PROXY".equals(name)) return testHttpProxyUrl;
                 return null;
             }
-            
+
             @Override
             protected URL createURL(String urlString) throws MalformedURLException {
                 if (urlString.equals(testHttpProxyUrl)) {
@@ -1161,33 +1160,33 @@ class GoogleAuthServiceTest {
                 }
                 return URI.create("https://example.com").toURL();
             }
-            
+
             @Override
             protected HttpURLConnection openProxyConnection(URL url, java.net.Proxy proxy) throws IOException {
                 // Return a mock connection that will succeed
                 HttpURLConnection mockConnection = mock(HttpURLConnection.class);
                 when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
-                
+
                 // Set up the mock input stream with our test response
                 InputStream mockStream = new ByteArrayInputStream(testResponse.getBytes());
                 when(mockConnection.getInputStream()).thenReturn(mockStream);
-                
+
                 return mockConnection;
             }
-            
+
             @Override
             protected HttpURLConnection openDirectConnection(URL url) {
                 fail("Should not use direct connection when no proxy is configured");
                 return null;
             }
         }
-        
+
         // Create the test service
         TestService service = new TestService();
-        
+
         // Execute
         String result = service.fetchUserData("test-token");
-        
+
         // Verify
         assertEquals(testResponse, result);
     }
@@ -1196,49 +1195,49 @@ class GoogleAuthServiceTest {
     void testFetchUserData_NoProxy() {
         // Setup test data
         String testResponse = "{\"birthdays\":[{\"date\":{\"year\":1990,\"month\":1,\"day\":1}}]}";
-        
+
         // Create a subclass that simulates no proxy configuration
         class TestService extends GoogleAuthService {
             public TestService() {
                 super(userService, jwtService, refreshTokenService);
             }
-            
+
             @Override
             protected String getEnv(String name) {
                 return null; // No proxies configured
             }
-            
+
             @Override
             protected URL createURL(String urlString) throws MalformedURLException {
                 return URI.create("https://example.com/api").toURL();
             }
-            
+
             @Override
             protected HttpURLConnection openDirectConnection(URL url) throws IOException {
                 // Return a mock connection that will succeed
                 HttpURLConnection mockConnection = mock(HttpURLConnection.class);
                 when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
-                
+
                 // Set up the mock input stream with our test response
                 InputStream mockStream = new ByteArrayInputStream(testResponse.getBytes());
                 when(mockConnection.getInputStream()).thenReturn(mockStream);
-                
+
                 return mockConnection;
             }
-            
+
             @Override
             protected HttpURLConnection openProxyConnection(URL url, java.net.Proxy proxy) {
                 fail("Should not use proxy connection when no proxy is configured");
                 return null;
             }
         }
-        
+
         // Create the test service 
         TestService service = new TestService();
-        
+
         // Execute
         String result = service.fetchUserData("test-token");
-        
+
         // Verify
         assertEquals(testResponse, result);
     }
@@ -1248,31 +1247,31 @@ class GoogleAuthServiceTest {
         // Setup mock environment with invalid HTTPS proxy
         String invalidProxyUrl = "invalid:proxy:url";
         String testResponse = "{\"birthdays\":[{\"date\":{\"year\":1990,\"month\":1,\"day\":1}}]}";
-        
+
         // Set private fields using reflection
         setPrivateField(googleAuthService, "httpsProxy", invalidProxyUrl);
         setPrivateField(googleAuthService, "httpProxy", null);
-        
+
         // Mock URL and connections
         URL mockUrl = mock(URL.class);
         doReturn(mockUrl).when(googleAuthService).createURL(PEOPLE_API_BASE_URL + "?personFields=" + "birthdays");
-        
+
         // Mock createURL to throw exception when used with the proxy URL
         doThrow(new MalformedURLException("Invalid proxy URL")).when(googleAuthService).createURL(invalidProxyUrl);
-        
+
         HttpURLConnection mockConnection = mock(HttpURLConnection.class);
         when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
-        
+
         // Create a mock InputStream with test response
         InputStream mockInputStream = new ByteArrayInputStream(testResponse.getBytes());
         when(mockConnection.getInputStream()).thenReturn(mockInputStream);
-        
+
         // Use a spy to intercept the connection methods
         doReturn(mockConnection).when(googleAuthService).openDirectConnection(any(URL.class));
-        
+
         // Execute
         String result = googleAuthService.fetchUserData("test-token");
-        
+
         // Verify
         assertEquals(testResponse, result);
         // Verify direct connection was used as fallback
@@ -1283,17 +1282,17 @@ class GoogleAuthServiceTest {
     @Test
     void testFetchUserData_ConnectionError() throws Exception {
         // Setup mock environment
-        
+
         // Mock URL
         URL mockUrl = mock(URL.class);
         doReturn(mockUrl).when(googleAuthService).createURL(anyString());
-        
+
         // Mock connection to throw IOException
         doThrow(new IOException("Connection error")).when(googleAuthService).openDirectConnection(any(URL.class));
-        
+
         // Execute
         String result = googleAuthService.fetchUserData("test-token");
-        
+
         // Verify
         assertNull(result);
         verify(googleAuthService).openDirectConnection(any(URL.class));
@@ -1302,24 +1301,24 @@ class GoogleAuthServiceTest {
     @Test
     void testFetchUserData_NonOkResponse() throws Exception {
         // Setup mock environment
-        
+
         // Mock URL and connections
         URL mockUrl = mock(URL.class);
         doReturn(mockUrl).when(googleAuthService).createURL(anyString());
-        
+
         HttpURLConnection mockConnection = mock(HttpURLConnection.class);
         when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_UNAUTHORIZED);
-        
+
         // Mock error stream
         InputStream mockErrorStream = new ByteArrayInputStream("{\"error\":\"Unauthorized\"}".getBytes());
         when(mockConnection.getErrorStream()).thenReturn(mockErrorStream);
-        
+
         // Use a spy to intercept the openDirectConnection method
         doReturn(mockConnection).when(googleAuthService).openDirectConnection(any(URL.class));
-        
+
         // Execute
         String result = googleAuthService.fetchUserData("test-token");
-        
+
         // Verify
         assertNull(result);
         verify(mockConnection).getErrorStream();
@@ -1330,22 +1329,22 @@ class GoogleAuthServiceTest {
         // Setup test data
         String emptyProxyUrl = "";  // Empty but not null
         String testResponse = "{\"birthdays\":[{\"date\":{\"year\":1990,\"month\":1,\"day\":1}}]}";
-        
+
         // Create a subclass that simulates empty HTTPS proxy configuration
         class TestService extends GoogleAuthService {
             private final Logger logger = (Logger) LoggerFactory.getLogger(GoogleAuthService.class);
-            
+
             public TestService() {
                 super(userService, jwtService, refreshTokenService);
             }
-            
+
             @Override
             protected String getEnv(String name) {
                 if ("HTTPS_PROXY".equals(name)) return emptyProxyUrl;
                 if ("HTTP_PROXY".equals(name)) return null;
                 return null;
             }
-            
+
             @Override
             protected URL createURL(String urlString) throws MalformedURLException {
                 // Explicitly log that no HTTPS proxy is being used
@@ -1354,47 +1353,47 @@ class GoogleAuthServiceTest {
                 }
                 return URI.create("https://example.com/api").toURL();
             }
-            
+
             @Override
             protected HttpURLConnection openDirectConnection(URL url) throws IOException {
                 // Return a mock connection that will succeed
                 HttpURLConnection mockConnection = mock(HttpURLConnection.class);
                 when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
-                
+
                 // Set up the mock input stream with our test response
                 InputStream mockStream = new ByteArrayInputStream(testResponse.getBytes());
                 when(mockConnection.getInputStream()).thenReturn(mockStream);
-                
+
                 return mockConnection;
             }
-            
+
             @Override
             protected HttpURLConnection openProxyConnection(URL url, java.net.Proxy proxy) {
                 fail("Should not use proxy connection when HTTPS proxy is empty");
                 return null;
             }
         }
-        
+
         // Create the test service
         TestService service = new TestService();
-        
+
         // Capture logs to verify the correct path was taken
         ch.qos.logback.core.read.ListAppender<ILoggingEvent> listAppender = new ch.qos.logback.core.read.ListAppender<>();
         listAppender.start();
         Logger logger = (Logger) LoggerFactory.getLogger(GoogleAuthService.class);
         logger.addAppender(listAppender);
-        
+
         try {
             // Execute
             String result = service.fetchUserData("test-token");
-            
+
             // Verify
             assertEquals(testResponse, result);
-            
+
             // Verify log indicating direct connection was used
             boolean foundDirectConnectionLog = listAppender.list.stream()
                     .anyMatch(event -> event.getMessage().contains("No HTTPS proxy configured, using direct connection"));
-            
+
             assertTrue(foundDirectConnectionLog, "Expected log about using direct connection was not found");
         } finally {
             logger.detachAppender(listAppender);
@@ -1406,22 +1405,22 @@ class GoogleAuthServiceTest {
         // Setup test data
         String invalidHttpProxyUrl = "invalid:url:format";
         String testResponse = "{\"birthdays\":[{\"date\":{\"year\":1990,\"month\":1,\"day\":1}}]}";
-        
+
         // Create a subclass that simulates HTTP proxy with malformed URL
         class TestService extends GoogleAuthService {
             private final Logger logger = (Logger) LoggerFactory.getLogger(GoogleAuthService.class);
-            
+
             public TestService() {
                 super(userService, jwtService, refreshTokenService);
             }
-            
+
             @Override
             protected String getEnv(String name) {
                 if ("HTTPS_PROXY".equals(name)) return null;
                 if ("HTTP_PROXY".equals(name)) return invalidHttpProxyUrl;
                 return null;
             }
-            
+
             @Override
             protected URL createURL(String urlString) throws MalformedURLException {
                 if (urlString.equals(invalidHttpProxyUrl)) {
@@ -1431,47 +1430,47 @@ class GoogleAuthServiceTest {
                 }
                 return URI.create("https://example.com/api").toURL();
             }
-            
+
             @Override
             protected HttpURLConnection openDirectConnection(URL url) throws IOException {
                 // Return a mock connection that will succeed
                 HttpURLConnection mockConnection = mock(HttpURLConnection.class);
                 when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
-                
+
                 // Set up the mock input stream with our test response
                 InputStream mockStream = new ByteArrayInputStream(testResponse.getBytes());
                 when(mockConnection.getInputStream()).thenReturn(mockStream);
-                
+
                 return mockConnection;
             }
-            
+
             @Override
             protected HttpURLConnection openProxyConnection(URL url, java.net.Proxy proxy) {
                 fail("Should not use proxy connection when HTTP proxy URL is malformed");
                 return null;
             }
         }
-        
+
         // Create the test service
         TestService service = new TestService();
-        
+
         // Capture logs to verify the correct path was taken
         ch.qos.logback.core.read.ListAppender<ILoggingEvent> listAppender = new ch.qos.logback.core.read.ListAppender<>();
         listAppender.start();
         Logger logger = (Logger) LoggerFactory.getLogger(GoogleAuthService.class);
         logger.addAppender(listAppender);
-        
+
         try {
             // Execute
             String result = service.fetchUserData("test-token");
-            
+
             // Verify
             assertEquals(testResponse, result);
-            
+
             // Verify log indicating direct connection was used as fallback
             boolean foundFallbackLog = listAppender.list.stream()
                     .anyMatch(event -> event.getMessage().contains("Invalid HTTP proxy URL, falling back to direct connection"));
-            
+
             assertTrue(foundFallbackLog, "Expected log about falling back to direct connection was not found");
         } finally {
             logger.detachAppender(listAppender);
@@ -1483,22 +1482,22 @@ class GoogleAuthServiceTest {
         // Setup test data
         String emptyProxyUrl = "";  // Empty but not null
         String testResponse = "{\"birthdays\":[{\"date\":{\"year\":1990,\"month\":1,\"day\":1}}]}";
-        
+
         // Create a subclass that simulates empty HTTP proxy configuration
         class TestService extends GoogleAuthService {
             private final Logger logger = (Logger) LoggerFactory.getLogger(GoogleAuthService.class);
-            
+
             public TestService() {
                 super(userService, jwtService, refreshTokenService);
             }
-            
+
             @Override
             protected String getEnv(String name) {
                 if ("HTTPS_PROXY".equals(name)) return null;
                 if ("HTTP_PROXY".equals(name)) return emptyProxyUrl;
                 return null;
             }
-            
+
             @Override
             protected URL createURL(String urlString) throws MalformedURLException {
                 // Explicitly log the expected message for empty HTTP proxy
@@ -1507,47 +1506,47 @@ class GoogleAuthServiceTest {
                 }
                 return URI.create("https://example.com/api").toURL();
             }
-            
+
             @Override
             protected HttpURLConnection openDirectConnection(URL url) throws IOException {
                 // Return a mock connection that will succeed
                 HttpURLConnection mockConnection = mock(HttpURLConnection.class);
                 when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
-                
+
                 // Set up the mock input stream with our test response
                 InputStream mockStream = new ByteArrayInputStream(testResponse.getBytes());
                 when(mockConnection.getInputStream()).thenReturn(mockStream);
-                
+
                 return mockConnection;
             }
-            
+
             @Override
             protected HttpURLConnection openProxyConnection(URL url, java.net.Proxy proxy) {
                 fail("Should not use proxy connection when HTTP proxy is empty");
                 return null;
             }
         }
-        
+
         // Create the test service
         TestService service = new TestService();
-        
+
         // Capture logs to verify the correct path was taken
         ch.qos.logback.core.read.ListAppender<ILoggingEvent> listAppender = new ch.qos.logback.core.read.ListAppender<>();
         listAppender.start();
         Logger logger = (Logger) LoggerFactory.getLogger(GoogleAuthService.class);
         logger.addAppender(listAppender);
-        
+
         try {
             // Execute
             String result = service.fetchUserData("test-token");
-            
+
             // Verify
             assertEquals(testResponse, result);
-            
+
             // Verify log indicating direct connection was used
             boolean foundDirectConnectionLog = listAppender.list.stream()
                     .anyMatch(event -> event.getMessage().contains("No HTTP proxy configured, using direct connection"));
-            
+
             assertTrue(foundDirectConnectionLog, "Expected log about using direct connection with empty HTTP proxy was not found");
         } finally {
             logger.detachAppender(listAppender);
@@ -1559,44 +1558,44 @@ class GoogleAuthServiceTest {
         // Setup mock environment
         URL mockUrl = mock(URL.class);
         doReturn(mockUrl).when(googleAuthService).createURL(anyString());
-        
+
         // Setup a mock connection that returns an error status
         HttpURLConnection mockConnection = mock(HttpURLConnection.class);
         when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
-        
+
         // Setup the error stream to throw an exception when read
         InputStream mockErrorStream = mock(InputStream.class);
         when(mockErrorStream.read(any(byte[].class))).thenThrow(new IOException("Error reading error stream"));
         when(mockConnection.getErrorStream()).thenReturn(mockErrorStream);
-        
+
         // Use a spy to intercept the connection methods
         doReturn(mockConnection).when(googleAuthService).openDirectConnection(any(URL.class));
-        
+
         // Capture logs to verify error handling
         ch.qos.logback.core.read.ListAppender<ILoggingEvent> listAppender = new ch.qos.logback.core.read.ListAppender<>();
         listAppender.start();
         Logger logger = (Logger) LoggerFactory.getLogger(GoogleAuthService.class);
         logger.addAppender(listAppender);
-        
+
         try {
             // Execute
             String result = googleAuthService.fetchUserData("test-token");
-            
+
             // Verify
             assertNull(result);
-            
+
             // Verify correct error logs were generated
             boolean foundReadErrorLog = listAppender.list.stream()
-                    .anyMatch(event -> event.getLevel() == Level.ERROR && 
-                             event.getFormattedMessage().contains("Could not read error response"));
-            
+                    .anyMatch(event -> event.getLevel() == Level.ERROR &&
+                            event.getFormattedMessage().contains("Could not read error response"));
+
             boolean foundApiErrorLog = listAppender.list.stream()
-                    .anyMatch(event -> event.getLevel() == Level.ERROR && 
-                             event.getFormattedMessage().contains("Error fetching data from Google API"));
-            
+                    .anyMatch(event -> event.getLevel() == Level.ERROR &&
+                            event.getFormattedMessage().contains("Error fetching data from Google API"));
+
             assertTrue(foundReadErrorLog, "Expected log about error reading error stream was not found");
             assertTrue(foundApiErrorLog, "Expected log about API error was not found");
-            
+
         } finally {
             logger.detachAppender(listAppender);
         }
@@ -1606,10 +1605,10 @@ class GoogleAuthServiceTest {
     void testOpenDirectConnection_WithActualURL() throws IOException {
         // Create a test URL for an actual site
         URL testUrl = URI.create("https://httpbin.org/get").toURL();
-        
+
         // Call the actual method (not a mock or subclass)
         HttpURLConnection result = googleAuthService.openDirectConnection(testUrl);
-        
+
         // Verify connection properties
         assertNotNull(result);
         assertEquals("GET", result.getRequestMethod());
@@ -1631,20 +1630,20 @@ class GoogleAuthServiceTest {
     void testOpenProxyConnection_WithActualURLAndProxy() throws IOException {
         // Skip test if we're not on a network that supports this
         assumeTrue(isNetworkAvailable(), "Network not available for proxy test");
-        
+
         // Create a test URL
         URL testUrl = URI.create("https://httpbin.org/get").toURL();
-        
+
         // Create a proxy - using a common test proxy port
         java.net.Proxy testProxy = new java.net.Proxy(
-                java.net.Proxy.Type.HTTP, 
+                java.net.Proxy.Type.HTTP,
                 new java.net.InetSocketAddress("localhost", 8888)
         );
-        
+
         try {
             // Try to create the connection (we don't need to connect, just verify it works)
             HttpURLConnection result = googleAuthService.openProxyConnection(testUrl, testProxy);
-            
+
             // Verify basic properties
             assertNotNull(result);
             assertEquals(testUrl, result.getURL());
@@ -1658,17 +1657,17 @@ class GoogleAuthServiceTest {
     void testCreateNetHttpTransport_NullHttpsProxy() throws Exception {
         // Set up the test environment
         setPrivateField(googleAuthService, "httpsProxy", null);
-        
+
         // Use reflection to access the private method
         Method method = GoogleAuthService.class.getDeclaredMethod("createNetHttpTransport");
         method.setAccessible(true);
         NetHttpTransport transport = (NetHttpTransport) method.invoke(googleAuthService);
-        
+
         // Capture logs to verify correct path
         verify(mockAppender).doAppend(loggingEventCaptor.capture());
         boolean hasDirectConnectionLog = loggingEventCaptor.getAllValues().stream()
                 .anyMatch(event -> event.getFormattedMessage().contains("No HTTPS proxy configured"));
-        
+
         // Verify
         assertNotNull(transport);
         assertTrue(hasDirectConnectionLog, "Should log that no proxy is configured");
@@ -1678,12 +1677,12 @@ class GoogleAuthServiceTest {
     void testCreateNetHttpTransport_EmptyHttpsProxy() throws Exception {
         // Set up the test environment
         setPrivateField(googleAuthService, "httpsProxy", "");
-        
+
         // Use reflection to access the private method
         Method method = GoogleAuthService.class.getDeclaredMethod("createNetHttpTransport");
         method.setAccessible(true);
         method.invoke(googleAuthService);
-        
+
         // Capture logs to verify correct path
         verify(mockAppender).doAppend(loggingEventCaptor.capture());
     }
@@ -1693,13 +1692,13 @@ class GoogleAuthServiceTest {
         // Set up the test environment with HTTPS proxy
         String testProxyUrl = "http://proxy.example.com:8443";
         setPrivateField(googleAuthService, "httpsProxy", testProxyUrl);
-        
+
         // Capture logs to verify proxy handling
         ch.qos.logback.core.read.ListAppender<ILoggingEvent> listAppender = new ch.qos.logback.core.read.ListAppender<>();
         listAppender.start();
         Logger logger = (Logger) LoggerFactory.getLogger(GoogleAuthService.class);
         logger.addAppender(listAppender);
-        
+
         try {
             // Override the createURL method to avoid actual network calls
             doAnswer(invocation -> {
@@ -1710,17 +1709,17 @@ class GoogleAuthServiceTest {
                 fail("Unexpected URL: " + urlString);
                 return null;
             }).when(googleAuthService).createURL(testProxyUrl);
-            
+
             // Call the method that uses createNetHttpTransport
             GoogleIdTokenVerifier googleVerifier = googleAuthService.createIdTokenVerifier();
-            
+
             // Verify result is not null
             assertNotNull(googleVerifier);
-            
+
             // Verify correct log message was generated for proxy usage
             boolean foundProxyLog = listAppender.list.stream()
                     .anyMatch(event -> event.getFormattedMessage().contains("Using HTTPS proxy for Google API client"));
-            
+
             assertTrue(foundProxyLog, "Expected log about using HTTPS proxy was not found");
         } finally {
             logger.detachAppender(listAppender);
@@ -1732,30 +1731,30 @@ class GoogleAuthServiceTest {
         // Set up the test environment with an invalid proxy
         String invalidProxyUrl = "invalid:proxy:url";
         setPrivateField(googleAuthService, "httpsProxy", invalidProxyUrl);
-        
+
         // Capture logs to verify proxy error handling
         ch.qos.logback.core.read.ListAppender<ILoggingEvent> listAppender = new ch.qos.logback.core.read.ListAppender<>();
         listAppender.start();
         Logger logger = (Logger) LoggerFactory.getLogger(GoogleAuthService.class);
         logger.addAppender(listAppender);
-        
+
         try {
             // Make createURL throw exception for the invalid proxy
             doThrow(new MalformedURLException("Invalid proxy URL"))
-                .when(googleAuthService).createURL(invalidProxyUrl);
-            
+                    .when(googleAuthService).createURL(invalidProxyUrl);
+
             // Call the method that uses createNetHttpTransport
-            GoogleAuthorizationCodeTokenRequest request = 
-                googleAuthService.createAuthorizationCodeTokenRequest("test-auth-code");
-            
+            GoogleAuthorizationCodeTokenRequest request =
+                    googleAuthService.createAuthorizationCodeTokenRequest("test-auth-code");
+
             // Verify result is not null (should succeed even with invalid proxy)
             assertNotNull(request);
-            
+
             // Verify error log about invalid proxy
             boolean foundErrorLog = listAppender.list.stream()
                     .anyMatch(event -> event.getLevel() == Level.ERROR &&
-                             event.getFormattedMessage().contains("Invalid HTTPS proxy URL"));
-            
+                            event.getFormattedMessage().contains("Invalid HTTPS proxy URL"));
+
             assertTrue(foundErrorLog, "Expected error log about invalid proxy URL was not found");
         } finally {
             logger.detachAppender(listAppender);
@@ -1766,24 +1765,24 @@ class GoogleAuthServiceTest {
     void testCreateIdTokenVerifier_WithEmptyProxy() throws Exception {
         // Set up the test environment with empty proxy
         setPrivateField(googleAuthService, "httpsProxy", "");
-        
+
         // Capture logs to verify proxy handling
         ch.qos.logback.core.read.ListAppender<ILoggingEvent> listAppender = new ch.qos.logback.core.read.ListAppender<>();
         listAppender.start();
         Logger logger = (Logger) LoggerFactory.getLogger(GoogleAuthService.class);
         logger.addAppender(listAppender);
-        
+
         try {
             // Call the method that uses createNetHttpTransport
             GoogleIdTokenVerifier googleVerifier = googleAuthService.createIdTokenVerifier();
-            
+
             // Verify result is not null
             assertNotNull(googleVerifier);
-            
+
             // Verify log about direct connection
             boolean foundDirectConnectionLog = listAppender.list.stream()
                     .anyMatch(event -> event.getFormattedMessage().contains("No HTTPS proxy configured"));
-            
+
             assertTrue(foundDirectConnectionLog, "Expected log about direct connection was not found");
         } finally {
             logger.detachAppender(listAppender);
@@ -1796,26 +1795,26 @@ class GoogleAuthServiceTest {
         String testHttpProxyUrl = "http://http-proxy.example.com:8080";
         setPrivateField(googleAuthService, "httpsProxy", null);
         setPrivateField(googleAuthService, "httpProxy", testHttpProxyUrl);
-        
+
         // Capture logs to verify proxy handling
         ch.qos.logback.core.read.ListAppender<ILoggingEvent> listAppender = new ch.qos.logback.core.read.ListAppender<>();
         listAppender.start();
         Logger logger = (Logger) LoggerFactory.getLogger(GoogleAuthService.class);
         logger.addAppender(listAppender);
-        
+
         try {
             // Call the method that uses createNetHttpTransport
-            GoogleAuthorizationCodeTokenRequest request = 
-                googleAuthService.createAuthorizationCodeTokenRequest("test-auth-code");
-            
+            GoogleAuthorizationCodeTokenRequest request =
+                    googleAuthService.createAuthorizationCodeTokenRequest("test-auth-code");
+
             // Verify result is not null
             assertNotNull(request);
-            
+
             // Verify correct log message was generated for direct connection
             // since createNetHttpTransport only looks at HTTPS_PROXY
             boolean foundNoProxyLog = listAppender.list.stream()
                     .anyMatch(event -> event.getFormattedMessage().contains("No HTTPS proxy configured"));
-            
+
             assertTrue(foundNoProxyLog, "Expected log about no HTTPS proxy was not found");
         } finally {
             logger.detachAppender(listAppender);
@@ -1826,26 +1825,26 @@ class GoogleAuthServiceTest {
     void testDirectOpenProxyConnection() throws Exception {
         // Create a real GoogleAuthService instance
         GoogleAuthService service = new GoogleAuthService(userService, jwtService, refreshTokenService);
-        
+
         // Create test URL 
         URL testUrl = URI.create("https://example.com").toURL();
-        
+
         // Create two different types of proxies to test
         java.net.Proxy httpProxy = new java.net.Proxy(
-                java.net.Proxy.Type.HTTP, 
+                java.net.Proxy.Type.HTTP,
                 new java.net.InetSocketAddress("proxy.example.com", 8080)
         );
-        
+
         java.net.Proxy socksProxy = new java.net.Proxy(
-                java.net.Proxy.Type.SOCKS, 
+                java.net.Proxy.Type.SOCKS,
                 new java.net.InetSocketAddress("socks.example.com", 1080)
         );
-        
+
         // Access the protected method directly via reflection
         Method openProxyConnectionMethod = GoogleAuthService.class.getDeclaredMethod(
                 "openProxyConnection", URL.class, java.net.Proxy.class);
         openProxyConnectionMethod.setAccessible(true);
-        
+
         // Test with HTTP proxy
         try {
             HttpURLConnection conn = (HttpURLConnection) openProxyConnectionMethod.invoke(service, testUrl, httpProxy);
@@ -1859,7 +1858,7 @@ class GoogleAuthServiceTest {
                 fail("Unexpected exception: " + e.getCause());
             }
         }
-        
+
         // Test with SOCKS proxy
         try {
             HttpURLConnection conn = (HttpURLConnection) openProxyConnectionMethod.invoke(service, testUrl, socksProxy);

--- a/src/test/java/com/safetypin/authentication/service/ProfileServiceTest.java
+++ b/src/test/java/com/safetypin/authentication/service/ProfileServiceTest.java
@@ -1,34 +1,5 @@
 package com.safetypin.authentication.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.lang.reflect.Method; // Keep reflection import
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.safetypin.authentication.dto.PostedByData;
 import com.safetypin.authentication.dto.ProfileResponse;
 import com.safetypin.authentication.dto.UpdateProfileRequest;
@@ -38,8 +9,22 @@ import com.safetypin.authentication.exception.ResourceNotFoundException;
 import com.safetypin.authentication.model.Role;
 import com.safetypin.authentication.model.User;
 import com.safetypin.authentication.repository.UserRepository;
-
 import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Method;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ProfileServiceTest {
@@ -272,7 +257,7 @@ class ProfileServiceTest {
             when(claims.getSubject()).thenReturn(userId.toString());
             when(userService.findById(userId)).thenReturn(Optional.of(testUser));
             when(userService.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0)); // Return saved
-                                                                                                         // user
+            // user
 
             // Act
             ProfileResponse response = profileService.updateProfile(userId, request, validToken);

--- a/src/test/java/com/safetypin/authentication/service/ProfileServiceTest.java
+++ b/src/test/java/com/safetypin/authentication/service/ProfileServiceTest.java
@@ -347,8 +347,8 @@ class ProfileServiceTest {
         // Assert
         assertEquals(2, result.size());
         
-        assertEquals(user1.getId(), result.get(0).getId());
-        assertEquals(user1.getName(), result.get(0).getName());
+        assertEquals(user1.getId(), result.getFirst().getId());
+        assertEquals(user1.getName(), result.getFirst().getName());
         assertEquals(user1.getProfilePicture(), result.get(0).getProfilePicture());
         assertEquals(user1.getProfileBanner(), result.get(0).getProfileBanner());
         

--- a/src/test/java/com/safetypin/authentication/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/safetypin/authentication/service/RefreshTokenServiceTest.java
@@ -62,7 +62,6 @@ class RefreshTokenServiceTest {
     void createRefreshToken_Success() {
         // Arrange
         when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
-        when(refreshTokenRepository.findByUserId(userId)).thenReturn(Optional.empty());
         when(refreshTokenRepository.save(any(RefreshToken.class))).thenReturn(testRefreshToken);
 
         // Act
@@ -106,7 +105,6 @@ class RefreshTokenServiceTest {
     void createRefreshToken_TokenAlreadyExists() {
         // Arrange
         when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
-        when(refreshTokenRepository.findByUserId(userId)).thenReturn(Optional.of(testRefreshToken));
         when(refreshTokenRepository.save(any(RefreshToken.class))).thenReturn(newTestRefreshToken);
 
         // Act

--- a/src/test/java/com/safetypin/authentication/service/UserServiceTest.java
+++ b/src/test/java/com/safetypin/authentication/service/UserServiceTest.java
@@ -1,26 +1,22 @@
 package com.safetypin.authentication.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
+import com.safetypin.authentication.model.User;
+import com.safetypin.authentication.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.safetypin.authentication.model.User;
-import com.safetypin.authentication.repository.UserRepository;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {

--- a/src/test/java/com/safetypin/authentication/service/UserServiceTest.java
+++ b/src/test/java/com/safetypin/authentication/service/UserServiceTest.java
@@ -1,20 +1,26 @@
 package com.safetypin.authentication.service;
 
-import com.safetypin.authentication.model.User;
-import com.safetypin.authentication.repository.UserRepository;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import com.safetypin.authentication.model.User;
+import com.safetypin.authentication.repository.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -108,6 +114,45 @@ class UserServiceTest {
         assertNotNull(savedUser);
         assertEquals(userToSave, savedUser);
         verify(userRepository).save(userToSave);
+    }
+
+    @Test
+    void testFindUsersByNameContaining_ShouldReturnMatchingUsers() {
+        // Arrange
+        String query = "test";
+        User user1 = new User();
+        user1.setName("Test User 1");
+        User user2 = new User();
+        user2.setName("Another Test User");
+        List<User> expectedUsers = Arrays.asList(user1, user2);
+
+        when(userRepository.findByNameContainingIgnoreCase(query)).thenReturn(expectedUsers);
+
+        // Act
+        List<User> result = userService.findUsersByNameContaining(query);
+
+        // Assert
+        assertEquals(expectedUsers, result);
+        verify(userRepository).findByNameContainingIgnoreCase(query);
+    }
+
+    @Test
+    void testFindAllUsers_ShouldReturnAllUsers() {
+        // Arrange
+        User user1 = new User();
+        user1.setName("User 1");
+        User user2 = new User();
+        user2.setName("User 2");
+        List<User> expectedUsers = Arrays.asList(user1, user2);
+
+        when(userRepository.findAll()).thenReturn(expectedUsers);
+
+        // Act
+        List<User> result = userService.findAllUsers();
+
+        // Assert
+        assertEquals(expectedUsers, result);
+        verify(userRepository).findAll();
     }
 
     @Test


### PR DESCRIPTION
This pull request introduces the getUsersBatch endpoint in the ProfileController to handle batch requests for retrieving user profile data.  

Changes:
- Added a new @PostMapping("/batch") method in ProfileController: Accepts a list of UUID user IDs in the request body, returns a Map<UUID, PostedByData> containing user profile data for the provided IDs.

Key Features
- Batch Processing: Allows be-post to retrieve multiple user profiles in a single request.
- Efficient Mapping: Returns a map of user IDs to their corresponding PostedByData objects.

This endpoint replaces the deprecated /api/profiles GET endpoint for retrieving all profiles.