### PR TITLE
Implement paginated user search

### DIFF
--- a/src/main/java/com/safetypin/authentication/controller/SearchController.java
+++ b/src/main/java/com/safetypin/authentication/controller/SearchController.java
@@ -3,12 +3,17 @@ package com.safetypin.authentication.controller;
 import com.safetypin.authentication.dto.UserResponse;
 import com.safetypin.authentication.model.User;
 import com.safetypin.authentication.service.UserService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Collections;
 import java.util.List;
 
 @RestController
@@ -21,16 +26,34 @@ public class SearchController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<List<UserResponse>> searchUsersByName(@RequestParam(required = false) String query) {
+    public ResponseEntity<Page<UserResponse>> searchUsersByName(
+            @RequestParam(required = false) String query,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
         List<User> users;
         if (query == null || query.trim().isEmpty()) {
             users = userService.findAllUsers(); // Fetch all users if no query is provided
         } else {
             users = userService.findUsersByNameContaining(query.trim());
         }
+
         List<UserResponse> userResponses = users.stream()
                 .map(User::generateUserResponse)
                 .toList(); // Use toList()
-        return ResponseEntity.ok(userResponses);
+
+
+
+
+        Pageable pageable = PageRequest.of(page, size);
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), userResponses.size());
+
+        List<UserResponse> userResponsesContent =
+                start >= userResponses.size() ? Collections.emptyList()
+                : userResponses.subList(start, end);
+
+        return ResponseEntity.ok(
+                new PageImpl<>(userResponsesContent, pageable, userResponses.size())
+        );
     }
 }

--- a/src/main/java/com/safetypin/authentication/controller/SearchController.java
+++ b/src/main/java/com/safetypin/authentication/controller/SearchController.java
@@ -39,10 +39,7 @@ public class SearchController {
 
         List<UserResponse> userResponses = users.stream()
                 .map(User::generateUserResponse)
-                .toList(); // Use toList()
-
-
-
+                .toList(); // TODO: Sort by followers count
 
         Pageable pageable = PageRequest.of(page, size);
         int start = (int) pageable.getOffset();

--- a/src/test/java/com/safetypin/authentication/controller/SearchControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/SearchControllerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -87,7 +88,14 @@ class SearchControllerTest {
             when(userService.findUsersByNameContaining(query)).thenReturn(johnUsers);
 
             // Act
-            ResponseEntity<List<UserResponse>> response = searchController.searchUsersByName(query);
+            ResponseEntity<Page<UserResponse>> paginatedResponse = searchController.searchUsersByName(query, 0, 10);
+            Page<UserResponse> page = paginatedResponse.getBody();
+            List<UserResponse> users = page != null ? page.getContent() : Collections.emptyList();
+
+            ResponseEntity<List<UserResponse>> response = ResponseEntity
+                    .status(paginatedResponse.getStatusCode())
+                    .headers(paginatedResponse.getHeaders())
+                    .body(users);
 
             // Assert
             assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -117,7 +125,14 @@ class SearchControllerTest {
             when(userService.findAllUsers()).thenReturn(allUsers);
 
             // Act
-            ResponseEntity<List<UserResponse>> response = searchController.searchUsersByName(null);
+            ResponseEntity<Page<UserResponse>> paginatedResponse = searchController.searchUsersByName(null, 0, 10);
+            Page<UserResponse> page = paginatedResponse.getBody();
+            List<UserResponse> users = page != null ? page.getContent() : Collections.emptyList();
+
+            ResponseEntity<List<UserResponse>> response = ResponseEntity
+                    .status(paginatedResponse.getStatusCode())
+                    .headers(paginatedResponse.getHeaders())
+                    .body(users);
 
             // Assert
             assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -144,7 +159,14 @@ class SearchControllerTest {
             when(userService.findAllUsers()).thenReturn(allUsers);
 
             // Act
-            ResponseEntity<List<UserResponse>> response = searchController.searchUsersByName(query);
+            ResponseEntity<Page<UserResponse>> paginatedResponse = searchController.searchUsersByName(query, 0, 10);
+            Page<UserResponse> page = paginatedResponse.getBody();
+            List<UserResponse> users = page != null ? page.getContent() : Collections.emptyList();
+
+            ResponseEntity<List<UserResponse>> response = ResponseEntity
+                    .status(paginatedResponse.getStatusCode())
+                    .headers(paginatedResponse.getHeaders())
+                    .body(users);
 
             // Assert
             assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -170,7 +192,14 @@ class SearchControllerTest {
             when(userService.findAllUsers()).thenReturn(allUsers);
 
             // Act
-            ResponseEntity<List<UserResponse>> response = searchController.searchUsersByName(query);
+            ResponseEntity<Page<UserResponse>> paginatedResponse = searchController.searchUsersByName(query, 0, 10);
+            Page<UserResponse> page = paginatedResponse.getBody();
+            List<UserResponse> users = page != null ? page.getContent() : Collections.emptyList();
+
+            ResponseEntity<List<UserResponse>> response = ResponseEntity
+                    .status(paginatedResponse.getStatusCode())
+                    .headers(paginatedResponse.getHeaders())
+                    .body(users);
 
             // Assert
             assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -196,7 +225,14 @@ class SearchControllerTest {
             when(userService.findUsersByNameContaining(query)).thenReturn(Collections.emptyList());
 
             // Act
-            ResponseEntity<List<UserResponse>> response = searchController.searchUsersByName(query);
+            ResponseEntity<Page<UserResponse>> paginatedResponse = searchController.searchUsersByName(query, 0, 10);
+            Page<UserResponse> page = paginatedResponse.getBody();
+            List<UserResponse> users = page != null ? page.getContent() : Collections.emptyList();
+
+            ResponseEntity<List<UserResponse>> response = ResponseEntity
+                    .status(paginatedResponse.getStatusCode())
+                    .headers(paginatedResponse.getHeaders())
+                    .body(users);
 
             // Assert
             assertEquals(HttpStatus.OK, response.getStatusCode());


### PR DESCRIPTION
Implemented paginated user search at api/users/search to improve efficiency.
Note that this search algorithm hasn't sort the users by any criteria.