### PR TITLE
Implement Profile View History & Refactor ProfileService to follow SOLID Principles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>3.12.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
 			<version>2.0.9</version>

--- a/src/main/java/com/safetypin/authentication/controller/ProfileController.java
+++ b/src/main/java/com/safetypin/authentication/controller/ProfileController.java
@@ -93,6 +93,26 @@ public class ProfileController {
         }
     }
 
+    @GetMapping("/me/views")
+    public ResponseEntity<AuthResponse> getProfileViews(@RequestHeader("Authorization") String authHeader) {
+        try {
+            UserResponse user = parseUserResponseFromAuthHeader(authHeader);
+            UUID userId = user.getId();
+
+            List<ProfileViewDTO> profileViews = profileService.getProfileViews(userId);
+            return ResponseEntity.ok(new AuthResponse(true, "Profile views retrieved successfully", profileViews));
+        } catch (InvalidCredentialsException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new AuthResponse(false, e.getMessage(), null));
+        } catch (ResourceNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new AuthResponse(false, e.getMessage(), null));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new AuthResponse(false, "Error retrieving profile views: " + e.getMessage(), null));
+        }
+    }
+
     @GetMapping
     public ResponseEntity<AuthResponse> getAllProfiles() {
         try {

--- a/src/main/java/com/safetypin/authentication/dto/ProfileResponse.java
+++ b/src/main/java/com/safetypin/authentication/dto/ProfileResponse.java
@@ -1,5 +1,6 @@
 package com.safetypin.authentication.dto;
 
+import com.safetypin.authentication.model.User;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
@@ -23,4 +24,21 @@ public class ProfileResponse {
     private String name;
     private String profilePicture;
     private String profileBanner;
+
+
+    public static ProfileResponse fromUser(User user) {
+        return ProfileResponse.builder()
+                .id(user.getId())
+                .role(user.getRole() != null ? user.getRole().name() : null)
+                .isVerified(user.isVerified())
+                .instagram(user.getInstagram())
+                .twitter(user.getTwitter())
+                .line(user.getLine())
+                .tiktok(user.getTiktok())
+                .discord(user.getDiscord())
+                .name(user.getName())
+                .profilePicture(user.getProfilePicture())
+                .profileBanner(user.getProfileBanner())
+                .build();
+    }
 }

--- a/src/main/java/com/safetypin/authentication/dto/ProfileViewDTO.java
+++ b/src/main/java/com/safetypin/authentication/dto/ProfileViewDTO.java
@@ -1,0 +1,16 @@
+package com.safetypin.authentication.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+public class ProfileViewDTO {
+    private UUID viewerUserId;
+    private String name;
+    private String profilePicture;
+    private LocalDateTime viewedAt;
+}

--- a/src/main/java/com/safetypin/authentication/model/ProfileView.java
+++ b/src/main/java/com/safetypin/authentication/model/ProfileView.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Data
@@ -22,7 +23,7 @@ public class ProfileView {
     @ManyToOne(fetch = FetchType.LAZY)
     private User viewer;
 
-    private LocalDate viewedAt;
+    private LocalDateTime viewedAt;
 }
 
 

--- a/src/main/java/com/safetypin/authentication/model/ProfileView.java
+++ b/src/main/java/com/safetypin/authentication/model/ProfileView.java
@@ -1,0 +1,28 @@
+package com.safetypin.authentication.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Data
+@Entity
+@Table(name = "profile_view")
+public class ProfileView {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @JoinColumn(name = "user_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @JoinColumn(name = "viewer_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User viewer;
+
+    private LocalDate viewedAt;
+}
+
+

--- a/src/main/java/com/safetypin/authentication/model/ProfileView.java
+++ b/src/main/java/com/safetypin/authentication/model/ProfileView.java
@@ -3,7 +3,6 @@ package com.safetypin.authentication.model;
 import jakarta.persistence.*;
 import lombok.Data;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 

--- a/src/main/java/com/safetypin/authentication/repository/ProfileViewRepository.java
+++ b/src/main/java/com/safetypin/authentication/repository/ProfileViewRepository.java
@@ -1,0 +1,14 @@
+package com.safetypin.authentication.repository;
+
+import com.safetypin.authentication.model.ProfileView;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ProfileViewRepository extends JpaRepository<ProfileView, UUID> {
+    Optional<ProfileView> findByUser_IdAndViewer_Id(UUID userId, UUID viewerId);
+
+    List<ProfileView> findByUser_Id(UUID userId);
+}

--- a/src/main/java/com/safetypin/authentication/service/JwtService.java
+++ b/src/main/java/com/safetypin/authentication/service/JwtService.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 
 @Service
 public class JwtService {
-    private static final long EXPIRATION_TIME = 100000L * 60 * 10; // 1000 milliseconds * 60 seconds * 10 minutes
+    private static final long EXPIRATION_TIME = 1000L * 60 * 10; // 1000 milliseconds * 60 seconds * 10 minutes
 
     private final Key key;
     private final UserService userService;

--- a/src/main/java/com/safetypin/authentication/service/ProfileService.java
+++ b/src/main/java/com/safetypin/authentication/service/ProfileService.java
@@ -33,12 +33,6 @@ public class ProfileService {
         this.profileViewRepository = profileViewRepository;
     }
 
-
-    // DEPRECATED, use getProfile(UUID, UUID) instead
-    public ProfileResponse getProfile(UUID userId) {
-        return getProfile(userId, null);
-    }
-
     public ProfileResponse getProfile(UUID userId, UUID viewerId) {
         User user = userService.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id " + userId));
@@ -67,12 +61,6 @@ public class ProfileService {
         }
 
         return ProfileResponse.fromUser(user);
-    }
-
-
-    // DEPRECATED, use updateProfile(UUID, UpdateProfileRequest) instead
-    public ProfileResponse updateProfile(UUID userId, UpdateProfileRequest request, String token) {
-        return updateProfile(userId, request);
     }
 
     public ProfileResponse updateProfile(UUID userId, UpdateProfileRequest request) {

--- a/src/main/java/com/safetypin/authentication/service/ProfileService.java
+++ b/src/main/java/com/safetypin/authentication/service/ProfileService.java
@@ -22,6 +22,8 @@ import java.util.regex.Pattern;
 
 @Service
 public class ProfileService {
+    private static final String USER_NOT_FOUND = "User not found with id ";
+    private static final String VIEWER_NOT_FOUND = "Viewer not found with id ";
 
     private final UserService userService;
 
@@ -35,14 +37,14 @@ public class ProfileService {
 
     public ProfileResponse getProfile(UUID userId, UUID viewerId) {
         User user = userService.findById(userId)
-                .orElseThrow(() -> new ResourceNotFoundException("User not found with id " + userId));
+                .orElseThrow(() -> new ResourceNotFoundException(USER_NOT_FOUND + userId));
 
         // Profile view tracking
         // Check if the viewer is the different as the user being viewed and not null
         if (viewerId != null && !viewerId.equals(userId)) {
             // Check if viewerId is a valid user
             User viewer = userService.findById(viewerId)
-                    .orElseThrow(() -> new ResourceNotFoundException("Viewer not found with id " + viewerId));
+                    .orElseThrow(() -> new ResourceNotFoundException(VIEWER_NOT_FOUND + viewerId));
 
             Optional<ProfileView> profileViewOpt = profileViewRepository.findByUser_IdAndViewer_Id(userId, viewerId);
             ProfileView profileView;
@@ -65,7 +67,7 @@ public class ProfileService {
 
     public ProfileResponse updateProfile(UUID userId, UpdateProfileRequest request) {
         User user = userService.findById(userId)
-                .orElseThrow(() -> new ResourceNotFoundException("User not found with id " + userId));
+                .orElseThrow(() -> new ResourceNotFoundException(USER_NOT_FOUND + userId));
 
         // Extract usernames from social media URLs and update fields
         user.setInstagram(extractInstagramUsername(request.getInstagram()));
@@ -99,7 +101,7 @@ public class ProfileService {
     public List<ProfileViewDTO> getProfileViews(UUID userId) throws InvalidCredentialsException {
         // Check if the user is premium
         User user = userService.findById(userId)
-                .orElseThrow(() -> new ResourceNotFoundException("User not found with id " + userId));
+                .orElseThrow(() -> new ResourceNotFoundException(USER_NOT_FOUND + userId));
         if (!user.getRole().toString().contains("PREMIUM")) {
             throw new InvalidCredentialsException("You need to be a premium user to view profile views.");
         }

--- a/src/main/java/com/safetypin/authentication/service/ProfileService.java
+++ b/src/main/java/com/safetypin/authentication/service/ProfileService.java
@@ -37,11 +37,11 @@ public class ProfileService {
     // TODO: Change all invocations to the other one (getProfile(UUID, String)) instead
     // DEPRECATED
     public ProfileResponse getProfile(UUID userId) {
-        return null;
+        return getProfile(userId, null);
     }
 
     public ProfileResponse getProfile(UUID userId, UUID viewerId) {
-
+        
 
         User user = userService.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id " + userId));
@@ -49,13 +49,11 @@ public class ProfileService {
         return ProfileResponse.fromUser(user);
     }
 
-    // TODO: Change all invocations to the other one (updateProfile(UUID, UpdateProfileRequest) instead
-    @Transactional
+    // TODO: Change all invocations to the other one (updateProfile(UUID, UpdateProfileRequest)) instead
     public ProfileResponse updateProfile(UUID userId, UpdateProfileRequest request, String token) {
-        return null;
+        return updateProfile(userId, request);
     }
 
-    @Transactional
     public ProfileResponse updateProfile(UUID userId, UpdateProfileRequest request) {
         User user = userService.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id " + userId));
@@ -74,23 +72,16 @@ public class ProfileService {
         return ProfileResponse.fromUser(savedUser);
     }
 
-    // If user is premium, return all profile views to that user
-    public List<ProfileViewDTO> getProfileViews(UUID userId) throws InvalidCredentialsException {
-        // Check if the user is premium
-        User user = userService.findById(userId)
-                .orElseThrow(() -> new ResourceNotFoundException("User not found with id " + userId));
-        if (!user.getRole().toString().contains("PREMIUM")) {
-            throw new InvalidCredentialsException("You need to be a premium user to view profile views.");
-        }
+    // Get all profiles
+    public List<UserPostResponse> getAllProfiles() {
+        List<User> users = userService.findAllUsers();
 
-        List<ProfileView> profileViews = profileViewRepository.findByUser_Id(userId);
-
-        return profileViews.stream()
-            .map(profileView -> ProfileViewDTO.builder()
-                .viewerUserId(profileView.getViewer().getId())
-                .name(profileView.getViewer().getName())
-                .profilePicture(profileView.getViewer().getProfilePicture())
-                .viewedAt(profileView.getViewedAt())
+        return users.stream()
+            .map(user -> UserPostResponse.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .profilePicture(user.getProfilePicture())
+                .profileBanner(user.getProfileBanner())
                 .build())
             .toList();
     }

--- a/src/main/java/com/safetypin/authentication/service/ProfileService.java
+++ b/src/main/java/com/safetypin/authentication/service/ProfileService.java
@@ -28,24 +28,15 @@ public class ProfileService {
         this.jwtService = jwtService;
     }
 
+    // anonymous get profile?
     public ProfileResponse getProfile(UUID userId) {
         User user = userService.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id " + userId));
 
-        return ProfileResponse.builder()
-                .id(user.getId())
-                .role(user.getRole() != null ? user.getRole().name() : null)
-                .isVerified(user.isVerified())
-                .instagram(user.getInstagram())
-                .twitter(user.getTwitter())
-                .line(user.getLine())
-                .tiktok(user.getTiktok())
-                .discord(user.getDiscord())
-                .name(user.getName())
-                .profilePicture(user.getProfilePicture())
-                .profileBanner(user.getProfileBanner())
-                .build();
+        return ProfileResponse.fromUser(user);
     }
+
+
 
     @Transactional
     public ProfileResponse updateProfile(UUID userId, UpdateProfileRequest request, String token) {
@@ -72,19 +63,7 @@ public class ProfileService {
 
             User savedUser = userService.save(user);
 
-            return ProfileResponse.builder()
-                    .id(savedUser.getId())
-                    .role(savedUser.getRole() != null ? savedUser.getRole().name() : null)
-                    .isVerified(savedUser.isVerified())
-                    .instagram(savedUser.getInstagram())
-                    .twitter(savedUser.getTwitter())
-                    .line(savedUser.getLine())
-                    .tiktok(savedUser.getTiktok())
-                    .discord(savedUser.getDiscord())
-                    .name(savedUser.getName())
-                    .profilePicture(savedUser.getProfilePicture())
-                    .profileBanner(savedUser.getProfileBanner())
-                    .build();
+            return ProfileResponse.fromUser(savedUser);
 
         } catch (Exception e) {
             throw new InvalidCredentialsException("Invalid or expired token");

--- a/src/test/java/com/safetypin/authentication/controller/ProfileControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/ProfileControllerTest.java
@@ -26,7 +26,7 @@ class ProfileControllerTest {
 
     @Mock
     private ProfileService profileService;
-    
+
     @Mock
     private JwtService jwtService;
 
@@ -76,7 +76,7 @@ class ProfileControllerTest {
         testUpdateRequest.setDiscord("newuser#5678");
         testUpdateRequest.setProfilePicture("https://example.com/profile.jpg");
         testUpdateRequest.setProfileBanner("https://example.com/banner.jpg");
-        
+
         // Set up test profiles list
         UserPostResponse profile1 = UserPostResponse.builder()
                 .id(testUserId)
@@ -84,16 +84,16 @@ class ProfileControllerTest {
                 .profilePicture("https://example.com/profile1.jpg")
                 .profileBanner("https://example.com/banner1.jpg")
                 .build();
-        
+
         UserPostResponse profile2 = UserPostResponse.builder()
                 .id(UUID.randomUUID())
                 .name("otheruser")
                 .profilePicture("https://example.com/profile2.jpg")
                 .profileBanner("https://example.com/banner2.jpg")
                 .build();
-        
+
         testAllProfiles = Arrays.asList(profile1, profile2);
-        
+
         // Configure JWT service mock
         when(jwtService.getUserFromJwtToken(testToken)).thenReturn(testUserResponse);
     }
@@ -103,7 +103,7 @@ class ProfileControllerTest {
     @Test
     void getProfile_Success() {
         // Arrange
-        when(profileService.getProfile(testUserId)).thenReturn(testProfileResponse);
+        when(profileService.getProfile(testUserId, null)).thenReturn(testProfileResponse);
 
         // Act
         ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId);
@@ -120,7 +120,7 @@ class ProfileControllerTest {
     @Test
     void getProfile_NotFound() {
         // Arrange
-        when(profileService.getProfile(testUserId))
+        when(profileService.getProfile(testUserId, null))
                 .thenThrow(new ResourceNotFoundException("User not found with id " + testUserId));
 
         // Act
@@ -139,7 +139,7 @@ class ProfileControllerTest {
     void getProfile_InternalServerError() {
         // Arrange
         String errorMessage = "Database connection error";
-        when(profileService.getProfile(testUserId))
+        when(profileService.getProfile(testUserId, null))
                 .thenThrow(new RuntimeException(errorMessage));
 
         // Act
@@ -153,17 +153,17 @@ class ProfileControllerTest {
         assertEquals("Error retrieving profile: " + errorMessage, body.getMessage());
         assertNull(body.getData());
     }
-    
+
     // GET MY PROFILE TESTS
-    
+
     @Test
     void getMyProfile_Success() {
         // Arrange
-        when(profileService.getProfile(testUserId)).thenReturn(testProfileResponse);
-        
+        when(profileService.getProfile(testUserId, testUserId)).thenReturn(testProfileResponse);
+
         // Act
         ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
-        
+
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
         AuthResponse body = response.getBody();
@@ -172,16 +172,16 @@ class ProfileControllerTest {
         assertEquals("Profile retrieved successfully", body.getMessage());
         assertEquals(testProfileResponse, body.getData());
     }
-    
+
     @Test
     void getMyProfile_NotFound() {
         // Arrange
-        when(profileService.getProfile(testUserId))
+        when(profileService.getProfile(testUserId, testUserId))
                 .thenThrow(new ResourceNotFoundException("User not found with id " + testUserId));
-        
+
         // Act
         ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
-        
+
         // Assert
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         AuthResponse body = response.getBody();
@@ -190,17 +190,17 @@ class ProfileControllerTest {
         assertEquals("User not found with id " + testUserId, body.getMessage());
         assertNull(body.getData());
     }
-    
+
     @Test
     void getMyProfile_InternalServerError() {
         // Arrange
         String errorMessage = "Database connection error";
-        when(profileService.getProfile(testUserId))
+        when(profileService.getProfile(testUserId, testUserId))
                 .thenThrow(new RuntimeException(errorMessage));
-        
+
         // Act
         ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
-        
+
         // Assert
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
         AuthResponse body = response.getBody();
@@ -215,7 +215,7 @@ class ProfileControllerTest {
     @Test
     void updateMyProfile_Success() {
         // Arrange
-        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
+        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class)))
                 .thenReturn(testProfileResponse);
 
         // Act
@@ -235,7 +235,7 @@ class ProfileControllerTest {
     void updateMyProfile_Unauthorized() {
         // Arrange
         String errorMessage = "You are not authorized to update this profile";
-        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
+        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class)))
                 .thenThrow(new InvalidCredentialsException(errorMessage));
 
         // Act
@@ -255,7 +255,7 @@ class ProfileControllerTest {
     void updateMyProfile_NotFound() {
         // Arrange
         String errorMessage = "User not found with id " + testUserId;
-        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
+        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class)))
                 .thenThrow(new ResourceNotFoundException(errorMessage));
 
         // Act
@@ -275,7 +275,7 @@ class ProfileControllerTest {
     void updateMyProfile_InternalServerError() {
         // Arrange
         String errorMessage = "Database update failed";
-        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class), eq(testToken)))
+        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class)))
                 .thenThrow(new RuntimeException(errorMessage));
 
         // Act
@@ -290,17 +290,17 @@ class ProfileControllerTest {
         assertEquals("Error updating profile: " + errorMessage, body.getMessage());
         assertNull(body.getData());
     }
-    
+
     // GET ALL PROFILES TESTS
-    
+
     @Test
     void getAllProfiles_Success() {
         // Arrange
         when(profileService.getAllProfiles()).thenReturn(testAllProfiles);
-        
+
         // Act
         ResponseEntity<AuthResponse> response = profileController.getAllProfiles();
-        
+
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
         AuthResponse body = response.getBody();
@@ -309,17 +309,17 @@ class ProfileControllerTest {
         assertEquals("All profiles retrieved successfully", body.getMessage());
         assertEquals(testAllProfiles, body.getData());
     }
-    
+
     @Test
     void getAllProfiles_InternalServerError() {
         // Arrange
         String errorMessage = "Database connection error";
         when(profileService.getAllProfiles())
                 .thenThrow(new RuntimeException(errorMessage));
-        
+
         // Act
         ResponseEntity<AuthResponse> response = profileController.getAllProfiles();
-        
+
         // Assert
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
         AuthResponse body = response.getBody();
@@ -329,3 +329,4 @@ class ProfileControllerTest {
         assertNull(body.getData());
     }
 }
+

--- a/src/test/java/com/safetypin/authentication/dto/ProfileResponseTest.java
+++ b/src/test/java/com/safetypin/authentication/dto/ProfileResponseTest.java
@@ -1,0 +1,65 @@
+package com.safetypin.authentication.dto;
+
+import com.safetypin.authentication.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProfileResponseTest {
+
+    @Test
+    void testFromUser() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        user.setRole(Role.REGISTERED_USER); // Assuming User.Role is an enum
+        user.setVerified(true);
+        user.setInstagram("user_instagram");
+        user.setTwitter("user_twitter");
+        user.setLine("user_line");
+        user.setTiktok("user_tiktok");
+        user.setDiscord("user_discord");
+        user.setName("John Doe");
+        user.setProfilePicture("profile_pic_url");
+        user.setProfileBanner("profile_banner_url");
+
+        // Act
+        ProfileResponse response = ProfileResponse.fromUser(user);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(userId, response.getId());
+        assertEquals(Role.REGISTERED_USER.toString(), response.getRole());
+        assertTrue(response.isVerified());
+        assertEquals("user_instagram", response.getInstagram());
+        assertEquals("user_twitter", response.getTwitter());
+        assertEquals("user_line", response.getLine());
+        assertEquals("user_tiktok", response.getTiktok());
+        assertEquals("user_discord", response.getDiscord());
+        assertEquals("John Doe", response.getName());
+        assertEquals("profile_pic_url", response.getProfilePicture());
+        assertEquals("profile_banner_url", response.getProfileBanner());
+    }
+
+    @Test
+    void testFromUserWithNullRole() {
+        // Arrange
+        UUID userId = UUID.randomUUID();
+        User user = new User();
+        user.setId(userId);
+        user.setRole(null); // Role is null
+        user.setVerified(false);
+
+        // Act
+        ProfileResponse response = ProfileResponse.fromUser(user);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(userId, response.getId());
+        assertNull(response.getRole());
+        assertFalse(response.isVerified());
+    }
+}

--- a/src/test/java/com/safetypin/authentication/repository/ProfileViewRepositoryTest.java
+++ b/src/test/java/com/safetypin/authentication/repository/ProfileViewRepositoryTest.java
@@ -1,0 +1,71 @@
+package com.safetypin.authentication.repository;
+
+import com.safetypin.authentication.model.ProfileView;
+import com.safetypin.authentication.model.Role;
+import com.safetypin.authentication.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class ProfileViewRepositoryTest {
+
+    @Autowired
+    private ProfileViewRepository profileViewRepository;
+
+    @Autowired
+    private UserRepository userRepository; // Assuming you have a UserRepository
+
+    private User registeredUser, premiumUser;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+        profileViewRepository.deleteAll();
+
+        // Create and save users with different roles
+        registeredUser = new User();
+        registeredUser.setEmail("registered@example.com");
+        registeredUser.setPassword("password");
+        registeredUser.setName("Registered User");
+        registeredUser.setRole(Role.REGISTERED_USER);
+        userRepository.save(registeredUser);
+
+        premiumUser = new User();
+        premiumUser.setEmail("premium@example.com");
+        premiumUser.setPassword("password");
+        premiumUser.setName("Premium User");
+        premiumUser.setRole(Role.PREMIUM_USER);
+        userRepository.save(premiumUser);
+
+        // Create and save a ProfileView
+        ProfileView profileView = new ProfileView();
+        profileView.setUser(premiumUser);
+        profileView.setViewer(registeredUser);
+        profileView.setViewedAt(LocalDate.now());
+        profileViewRepository.save(profileView);
+    }
+
+    @Test
+    void testFindByUser_IdAndViewer_Id() {
+        Optional<ProfileView> result = profileViewRepository.findByUser_IdAndViewer_Id(
+                premiumUser.getId(), registeredUser.getId());
+        assertThat(result).isPresent();
+        assertThat(result.get().getUser()).isEqualTo(premiumUser);
+        assertThat(result.get().getViewer()).isEqualTo(registeredUser);
+    }
+
+    @Test
+    void testFindByUser_Id() {
+        List<ProfileView> result = profileViewRepository.findByUser_Id(premiumUser.getId());
+        assertThat(result).isNotEmpty();
+        assertThat(result.getFirst().getUser()).isEqualTo(premiumUser);
+    }
+}

--- a/src/test/java/com/safetypin/authentication/repository/ProfileViewRepositoryTest.java
+++ b/src/test/java/com/safetypin/authentication/repository/ProfileViewRepositoryTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -49,7 +49,7 @@ class ProfileViewRepositoryTest {
         ProfileView profileView = new ProfileView();
         profileView.setUser(premiumUser);
         profileView.setViewer(registeredUser);
-        profileView.setViewedAt(LocalDate.now());
+        profileView.setViewedAt(LocalDateTime.now());
         profileViewRepository.save(profileView);
     }
 

--- a/src/test/java/com/safetypin/authentication/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/safetypin/authentication/repository/RefreshTokenRepositoryTest.java
@@ -9,8 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/safetypin/authentication/service/ProfileServiceTest.java
+++ b/src/test/java/com/safetypin/authentication/service/ProfileServiceTest.java
@@ -43,13 +43,10 @@ class ProfileServiceTest {
 
     private UUID userId, premiumUserId;
     private User testUser, testPremiumUser;
-    private String validToken;
 
     @BeforeEach
     void setUp() {
         userId = UUID.randomUUID();
-        validToken = "valid.jwt.token";
-
         testUser = new User();
         testUser.setId(userId);
         testUser.setRole(Role.REGISTERED_USER);
@@ -59,7 +56,6 @@ class ProfileServiceTest {
         testUser.setLine("testline");
         testUser.setTiktok("testtiktok");
         testUser.setDiscord("testdiscord");
-
 
         premiumUserId = UUID.randomUUID();
         testPremiumUser = new User();
@@ -79,7 +75,7 @@ class ProfileServiceTest {
         when(userService.findById(userId)).thenReturn(Optional.of(testUser));
 
         // Act
-        ProfileResponse response = profileService.getProfile(userId);
+        ProfileResponse response = profileService.getProfile(userId, null);
 
         // Assert
         assertNotNull(response);
@@ -103,7 +99,7 @@ class ProfileServiceTest {
         // Act & Assert
         ResourceNotFoundException exception = assertThrows(
                 ResourceNotFoundException.class,
-                () -> profileService.getProfile(userId)
+                () -> profileService.getProfile(userId, null)
         );
 
         assertEquals("User not found with id " + userId, exception.getMessage());
@@ -124,7 +120,7 @@ class ProfileServiceTest {
         request.setDiscord("newdiscord#1234");
 
         // Act
-        ProfileResponse response = profileService.updateProfile(userId, request, validToken);
+        ProfileResponse response = profileService.updateProfile(userId, request);
 
         // Assert
         assertNotNull(response);
@@ -144,7 +140,7 @@ class ProfileServiceTest {
         // Act & Assert
         ResourceNotFoundException exception = assertThrows(
                 ResourceNotFoundException.class,
-                () -> profileService.updateProfile(userId, request, validToken)
+                () -> profileService.updateProfile(userId, request)
         );
 
         assertTrue(exception.getMessage().contains("User not found with id"));
@@ -332,7 +328,7 @@ class ProfileServiceTest {
         UpdateProfileRequest request = new UpdateProfileRequest();
         
         // Act
-        ProfileResponse response = profileService.updateProfile(userId, request, validToken);
+        ProfileResponse response = profileService.updateProfile(userId, request);
 
         // Assert
         assertNotNull(response);
@@ -353,7 +349,7 @@ class ProfileServiceTest {
         when(userService.findById(userId)).thenReturn(Optional.of(userWithNullRole));
 
         // Act
-        ProfileResponse response = profileService.getProfile(userId);
+        ProfileResponse response = profileService.getProfile(userId, null);
 
         // Assert
         assertNotNull(response);

--- a/src/test/java/com/safetypin/authentication/service/ProfileServiceTest.java
+++ b/src/test/java/com/safetypin/authentication/service/ProfileServiceTest.java
@@ -14,6 +14,9 @@ import com.safetypin.authentication.repository.ProfileViewRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -24,6 +27,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.List;
 import java.util.Arrays;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -149,58 +153,53 @@ class ProfileServiceTest {
         verify(userService, never()).save(any());
     }
 
-    @Test
-    void extractInstagramUsername_FromUrl_ReturnsUsername() throws Exception {
+    @ParameterizedTest
+    @MethodSource("provideUsernameCases")
+    void extractUsername_FromUrl_ReturnsUsername(String methodName, String expected, String input) throws Exception {
         // Use reflection to access private method
-        java.lang.reflect.Method method = ProfileService.class.getDeclaredMethod("extractInstagramUsername", String.class);
+        java.lang.reflect.Method method = ProfileService.class.getDeclaredMethod(methodName, String.class);
         method.setAccessible(true);
 
-        // Test with URL format
-        String result1 = (String) method.invoke(profileService, "instagram.com/username");
-        assertEquals("username", result1);
-
-        // Test with @ in URL
-        String result2 = (String) method.invoke(profileService, "instagram.com/@username");
-        assertEquals("username", result2);
-
-        // Test with just username
-        String result3 = (String) method.invoke(profileService, "username");
-        assertEquals("username", result3);
-
-        // Test with null
-        String result4 = (String) method.invoke(profileService, (Object) null);
-        assertNull(result4);
-
-        // Test with empty string
-        String result5 = (String) method.invoke(profileService, "");
-        assertNull(result5);
+        // Test the extraction
+        String result = (String) method.invoke(profileService, input);
+        assertEquals(expected, result);
     }
 
-    @Test
-    void extractTwitterUsername_FromUrl_ReturnsUsername() throws Exception {
-        // Use reflection to access private method
-        java.lang.reflect.Method method = ProfileService.class.getDeclaredMethod("extractTwitterUsername", String.class);
-        method.setAccessible(true);
+    static Stream<Arguments> provideUsernameCases() {
+        return Stream.of(
+                // Instagram cases
+                // 1. Username extraction from URL
+                Arguments.of("extractInstagramUsername", "username", "instagram.com/username"),
+                Arguments.of("extractInstagramUsername", "username", "instagram.com/@username"),
+                // 2. Username extraction from plain username
+                Arguments.of("extractInstagramUsername", "username", "username"),
+                // 3. Null or empty cases
+                Arguments.of("extractInstagramUsername", null, null),
+                Arguments.of("extractInstagramUsername", null, ""),
+                Arguments.of("extractInstagramUsername", null, " "),
 
-        // Test with URL format
-        String result1 = (String) method.invoke(profileService, "twitter.com/username");
-        assertEquals("username", result1);
+                // Twitter cases
+                // 1. Username extraction from URL
+                Arguments.of("extractTwitterUsername", "username", "twitter.com/username"),
+                Arguments.of("extractTwitterUsername", "username", "twitter.com/@username"),
+                // 2. Username extraction from plain username
+                Arguments.of("extractTwitterUsername", "username", "username"),
+                // 3. Null or empty cases
+                Arguments.of("extractTwitterUsername", null, null),
+                Arguments.of("extractTwitterUsername", null, ""),
+                Arguments.of("extractTwitterUsername", null, " "),
 
-        // Test with @ in URL
-        String result2 = (String) method.invoke(profileService, "twitter.com/@username");
-        assertEquals("username", result2);
-
-        // Test with just username
-        String result3 = (String) method.invoke(profileService, "username");
-        assertEquals("username", result3);
-
-        // Test with null
-        String result4 = (String) method.invoke(profileService, (Object) null);
-        assertNull(result4);
-
-        // Test with empty string
-        String result5 = (String) method.invoke(profileService, "");
-        assertNull(result5);
+                // TikTok cases
+                // 1. Username extraction from URL
+                Arguments.of("extractTiktokUsername", "username", "tiktok.com/username"),
+                Arguments.of("extractTiktokUsername", "username", "tiktok.com/@username"),
+                // 2. Username extraction from plain username
+                Arguments.of("extractTiktokUsername", "username", "username"),
+                // 3. Null or empty cases
+                Arguments.of("extractTiktokUsername", null, null),
+                Arguments.of("extractTiktokUsername", null, ""),
+                Arguments.of("extractTiktokUsername", null, " ")
+        );
     }
 
     @Test
@@ -224,33 +223,6 @@ class ProfileServiceTest {
         // Test with empty string
         String result4 = (String) method.invoke(profileService, "");
         assertNull(result4);
-    }
-
-    @Test
-    void extractTiktokUsername_FromUrl_ReturnsUsername() throws Exception {
-        // Use reflection to access private method
-        java.lang.reflect.Method method = ProfileService.class.getDeclaredMethod("extractTiktokUsername", String.class);
-        method.setAccessible(true);
-
-        // Test with URL format
-        String result1 = (String) method.invoke(profileService, "tiktok.com/username");
-        assertEquals("username", result1);
-
-        // Test with @ in URL
-        String result2 = (String) method.invoke(profileService, "tiktok.com/@username");
-        assertEquals("username", result2);
-
-        // Test with just username
-        String result3 = (String) method.invoke(profileService, "username");
-        assertEquals("username", result3);
-
-        // Test with null
-        String result4 = (String) method.invoke(profileService, (Object) null);
-        assertNull(result4);
-
-        // Test with empty string
-        String result5 = (String) method.invoke(profileService, "");
-        assertNull(result5);
     }
 
     @Test
@@ -505,7 +477,6 @@ class ProfileServiceTest {
     @Test
     void getProfileViews_UserNotFound_ThrowsResourceNotFoundException() {
         // Arrange
-        UUID userId = UUID.randomUUID();
         when(userService.findById(userId)).thenReturn(Optional.empty());
 
         // Act & Assert


### PR DESCRIPTION
This PR implements the profile view history tracking and retrieval, with proper authorization. It also refactors the profile service as a whole to clean up the code and implement SRP.

Work done:
- New endpoint ("/api/profiles/me/views"), If the user is authenticated (with JWT token) and the user is a premium user, then it returns all the views shown on the profile.
- Decouple JWTService from ProfileService and put authentication in the controller. (SRP)
- Change UserRepository to UserService in ProfileService

Todo:
- Pagination in profile view based on view date and other filters