### PR TITLE
Enable editing of username

### DIFF
--- a/src/main/java/com/safetypin/authentication/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/safetypin/authentication/dto/UpdateProfileRequest.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class UpdateProfileRequest {
+    private String name;
     private String instagram;
     private String twitter;
     private String line;

--- a/src/main/java/com/safetypin/authentication/model/User.java
+++ b/src/main/java/com/safetypin/authentication/model/User.java
@@ -1,14 +1,22 @@
 package com.safetypin.authentication.model;
 
+import java.time.LocalDate;
+import java.util.UUID;
+
 import com.safetypin.authentication.dto.UserResponse;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.time.LocalDate;
-import java.util.UUID;
 
 @Entity
 @Table(name = "users")
@@ -33,7 +41,7 @@ public class User {
 
     @Setter
     @Getter
-    @Column(nullable = false)
+    @Column(nullable = false, length = 100)
     private String name;
 
     @Getter // Explicitly add getter for boolean field for Jackson/Lombok interaction

--- a/src/main/java/com/safetypin/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/safetypin/authentication/service/AuthenticationService.java
@@ -46,6 +46,9 @@ public class AuthenticationService {
         if (calculateAge(request.getBirthdate()) < 16) {
             throw new IllegalArgumentException("User must be at least 16 years old");
         }
+        if (request.getName().length() > 100) {
+            throw new IllegalArgumentException("Name must not exceed 100 characters");
+        }
         Optional<User> existingUserOpt = userService.findByEmail(request.getEmail());
         if (existingUserOpt.isPresent()) {
             User existingUser = existingUserOpt.get();

--- a/src/main/java/com/safetypin/authentication/service/ProfileService.java
+++ b/src/main/java/com/safetypin/authentication/service/ProfileService.java
@@ -88,6 +88,9 @@ public class ProfileService {
 
         // Update fields only if they are provided (not null) in the request
         if (request.getName() != null) {
+            if (request.getName().length() > 100) {
+                throw new IllegalArgumentException("Name must not exceed 100 characters");
+            }
             user.setName(request.getName());
         }
         if (request.getInstagram() != null) {

--- a/src/main/java/com/safetypin/authentication/service/ProfileService.java
+++ b/src/main/java/com/safetypin/authentication/service/ProfileService.java
@@ -1,5 +1,18 @@
 package com.safetypin.authentication.service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.safetypin.authentication.dto.PostedByData;
 import com.safetypin.authentication.dto.ProfileResponse;
 import com.safetypin.authentication.dto.ProfileViewDTO;
@@ -10,18 +23,6 @@ import com.safetypin.authentication.exception.ResourceNotFoundException;
 import com.safetypin.authentication.model.ProfileView;
 import com.safetypin.authentication.model.User;
 import com.safetypin.authentication.repository.ProfileViewRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 @Service
 public class ProfileService {
@@ -33,7 +34,8 @@ public class ProfileService {
     private final FollowService followService;
 
     @Autowired
-    public ProfileService(UserService userService, ProfileViewRepository profileViewRepository, FollowService followService) {
+    public ProfileService(UserService userService, ProfileViewRepository profileViewRepository,
+            FollowService followService) {
         this.userService = userService;
         this.profileViewRepository = profileViewRepository;
         this.followService = followService;
@@ -77,8 +79,7 @@ public class ProfileService {
                 user,
                 followService.getFollowersCount(userId),
                 followService.getFollowingCount(userId),
-                isFollowing
-        );
+                isFollowing);
     }
 
     public ProfileResponse updateProfile(UUID userId, UpdateProfileRequest request) {
@@ -86,6 +87,9 @@ public class ProfileService {
                 .orElseThrow(() -> new ResourceNotFoundException(USER_NOT_FOUND + userId));
 
         // Update fields only if they are provided (not null) in the request
+        if (request.getName() != null) {
+            user.setName(request.getName());
+        }
         if (request.getInstagram() != null) {
             user.setInstagram(extractInstagramUsername(request.getInstagram()));
         }
@@ -114,8 +118,7 @@ public class ProfileService {
                 savedUser,
                 followService.getFollowersCount(userId),
                 followService.getFollowingCount(userId),
-                false
-        );
+                false);
     }
 
     // Get all profiles
@@ -144,15 +147,14 @@ public class ProfileService {
         List<ProfileView> profileViews = profileViewRepository.findByUser_Id(userId);
 
         return profileViews.stream()
-            .map(profileView -> ProfileViewDTO.builder()
-                .viewerUserId(profileView.getViewer().getId())
-                .name(profileView.getViewer().getName())
-                .profilePicture(profileView.getViewer().getProfilePicture())
-                .viewedAt(profileView.getViewedAt())
-                .build())
-            .toList();
+                .map(profileView -> ProfileViewDTO.builder()
+                        .viewerUserId(profileView.getViewer().getId())
+                        .name(profileView.getViewer().getName())
+                        .profilePicture(profileView.getViewer().getProfilePicture())
+                        .viewedAt(profileView.getViewedAt())
+                        .build())
+                .toList();
     }
-
 
     public Map<UUID, PostedByData> getUsersBatch(List<UUID> userIds) {
         if (userIds == null || userIds.isEmpty()) {
@@ -168,8 +170,6 @@ public class ProfileService {
                                 .profilePicture(user.getProfilePicture())
                                 .build()));
     }
-
-
 
     // Helper methods to extract usernames from social media URLs
 

--- a/src/test/java/com/safetypin/authentication/controller/AuthenticationControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/AuthenticationControllerTest.java
@@ -1,15 +1,16 @@
 package com.safetypin.authentication.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.safetypin.authentication.dto.*;
-import com.safetypin.authentication.exception.InvalidCredentialsException;
-import com.safetypin.authentication.exception.UserAlreadyExistsException;
-import com.safetypin.authentication.model.Role;
-import com.safetypin.authentication.model.User;
-import com.safetypin.authentication.service.AuthenticationService;
-import com.safetypin.authentication.service.GoogleAuthService;
-import com.safetypin.authentication.service.JwtService;
-import com.safetypin.authentication.service.RefreshTokenService;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,547 +24,589 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.LocalDate;
-import java.util.UUID;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.safetypin.authentication.dto.AuthToken;
+import com.safetypin.authentication.dto.GoogleAuthDTO;
+import com.safetypin.authentication.dto.LoginRequest;
+import com.safetypin.authentication.dto.OTPRequest;
+import com.safetypin.authentication.dto.PasswordResetRequest;
+import com.safetypin.authentication.dto.PasswordResetWithOTPRequest;
+import com.safetypin.authentication.dto.RegistrationRequest;
+import com.safetypin.authentication.dto.UserResponse;
+import com.safetypin.authentication.dto.VerifyResetOTPRequest;
+import com.safetypin.authentication.exception.InvalidCredentialsException;
+import com.safetypin.authentication.exception.PendingVerificationException;
+import com.safetypin.authentication.exception.UserAlreadyExistsException;
+import com.safetypin.authentication.model.Role;
+import com.safetypin.authentication.model.User;
+import com.safetypin.authentication.service.AuthenticationService;
+import com.safetypin.authentication.service.GoogleAuthService;
+import com.safetypin.authentication.service.JwtService;
+import com.safetypin.authentication.service.RefreshTokenService;
 
 @WebMvcTest(AuthenticationController.class)
-@Import({AuthenticationControllerTest.TestConfig.class})
+@Import({ AuthenticationControllerTest.TestConfig.class })
 class AuthenticationControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private AuthenticationService authenticationService;
-
-    @Autowired
-    private GoogleAuthService googleAuthService;
-
-    @Autowired
-    private JwtService jwtService;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @Test
-    void testRegisterEmail() throws Exception {
-        RegistrationRequest request = new RegistrationRequest();
-        request.setEmail("email@example.com");
-        request.setPassword("password");
-        request.setName("Test User");
-        request.setBirthdate(LocalDate.now().minusYears(20));
-
-        User user = new User();
-        user.setEmail("email@example.com");
-        user.setPassword("encodedPassword");
-        user.setName("Test User");
-        user.setRole(Role.REGISTERED_USER);
-        user.setBirthdate(request.getBirthdate());
-        user.setProvider("EMAIL");
-
-        UUID userId = UUID.randomUUID();
-        user.setId(userId);
-
-        String accessToken = jwtService.generateToken(user.getId());
-        String refreshToken = "test-refresh-token";
-        AuthToken returnToken = new AuthToken(userId, accessToken, refreshToken);
-
-        Mockito.when(authenticationService.registerUser(any(RegistrationRequest.class))).thenReturn(returnToken);
-
-        mockMvc.perform(post("/api/auth/register-email")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("OK"))
-                .andExpect(jsonPath("$.data.userId").value(userId.toString()))
-                .andExpect(jsonPath("$.data.accessToken").value(accessToken))
-                .andExpect(jsonPath("$.data.refreshToken").value(refreshToken));
-    }
-
-    @Test
-    void testLoginEmail() throws Exception {
-        User user = new User();
-        user.setEmail("email@example.com");
-        user.setPassword("encodedPassword");
-        user.setName("Test User");
-        user.setVerified(true);
-        user.setRole(Role.REGISTERED_USER);
-        user.setBirthdate(LocalDate.now().minusYears(20));
-        user.setProvider("EMAIL");
-
-        UUID userId = UUID.randomUUID();
-        user.setId(userId);
-
-
-        // Create LoginRequest object
-        LoginRequest loginRequest = new LoginRequest();
-        loginRequest.setEmail("email@example.com");
-        loginRequest.setPassword("password");
-
-        String accessToken = jwtService.generateToken(user.getId());
-        String refreshToken = "test-refresh-token";
-        AuthToken returnToken = new AuthToken(userId, accessToken, refreshToken);
-
-        Mockito.when(authenticationService.loginUser("email@example.com", "password")).thenReturn(returnToken);
-
-        mockMvc.perform(post("/api/auth/login-email")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequest)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.accessToken").value(accessToken))
-                .andExpect(jsonPath("$.data.refreshToken").value(refreshToken));
-    }
-
-    @Test
-    void testLoginEmail_InvalidCredentials() throws Exception {
-        // Prepare test data
-        String email = "email@example.com";
-        String password = "invalidPassword";
-
-        // Create LoginRequest object
-        LoginRequest loginRequest = new LoginRequest();
-        loginRequest.setEmail(email);
-        loginRequest.setPassword(password);
-
-        // Mock the service method to throw InvalidCredentialsException
-        Mockito.when(authenticationService.loginUser(email, password))
-                .thenThrow(new InvalidCredentialsException("Invalid email or password"));
-
-        // Perform the test
-        mockMvc.perform(post("/api/auth/login-email")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequest)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value("Invalid email or password"))
-                .andExpect(jsonPath("$.data").doesNotExist()); // No data expected in case of error
-    }
-
-    @Test
-    void testVerifyOTP_Success() throws Exception {
-        // Create OTPRequest object
-        OTPRequest otpRequest = new OTPRequest();
-        otpRequest.setEmail("email@example.com");
-        otpRequest.setOtp("123456");
-
-        Mockito.when(authenticationService.verifyOTP("email@example.com", "123456")).thenReturn(true);
-
-        mockMvc.perform(post("/api/auth/verify-otp")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(otpRequest)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("User verified successfully"));
-    }
-
-    @Test
-    void testVerifyOTP_Failure() throws Exception {
-        // Create OTPRequest object
-        OTPRequest otpRequest = new OTPRequest();
-        otpRequest.setEmail("email@example.com");
-        otpRequest.setOtp("000000");
-
-        Mockito.when(authenticationService.verifyOTP("email@example.com", "000000")).thenReturn(false);
-
-        mockMvc.perform(post("/api/auth/verify-otp")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(otpRequest)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value("OTP verification failed"));
-    }
-
-    @Test
-    void testVerifyOTP_InvalidCredentials() throws Exception {
-        // Create OTPRequest with invalid data
-        OTPRequest otpRequest = new OTPRequest();
-        otpRequest.setEmail("email@example.com");
-        otpRequest.setOtp("invalid");
-
-        // Just mock the service to throw the exception
-        Mockito.when(authenticationService.verifyOTP("email@example.com", "invalid"))
-                .thenReturn(false);
-
-        // Only check that the status is 400 (Bad Request)
-        mockMvc.perform(post("/api/auth/verify-otp")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(otpRequest)))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void testForgotPassword() throws Exception {
-        PasswordResetRequest request = new PasswordResetRequest();
-        request.setEmail("email@example.com");
-
-        Mockito.doNothing().when(authenticationService).forgotPassword("email@example.com");
-
-        mockMvc.perform(post("/api/auth/forgot-password")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("Password reset OTP has been sent to your email"));
-    }
-
-    @Test
-    void testForgotPassword_IllegalArgumentException() throws Exception {
-        PasswordResetRequest request = new PasswordResetRequest();
-        request.setEmail("social-login@example.com");
-
-        // Mock the service to throw IllegalArgumentException
-        String errorMessage = "Password reset is only available for email-registered users.";
-        Mockito.doThrow(new IllegalArgumentException(errorMessage))
-                .when(authenticationService).forgotPassword("social-login@example.com");
-
-        mockMvc.perform(post("/api/auth/forgot-password")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value(errorMessage))
-                .andExpect(jsonPath("$.data").doesNotExist());
-    }
-
-    @Test
-    void testVerifyResetOTP_Success() throws Exception {
-        VerifyResetOTPRequest request = new VerifyResetOTPRequest();
-        request.setEmail("email@example.com");
-        request.setOtp("123456");
-
-        Mockito.when(authenticationService.verifyPasswordResetOTP("email@example.com", "123456")).thenReturn("reset-token-123");
-
-        mockMvc.perform(post("/api/auth/verify-reset-otp")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("OTP verified successfully. Reset token valid for 3 minutes."))
-                .andExpect(jsonPath("$.data.resetToken").value("reset-token-123"));
-    }
-
-    @Test
-    void testVerifyResetOTP_Failure() throws Exception {
-        VerifyResetOTPRequest request = new VerifyResetOTPRequest();
-        request.setEmail("email@example.com");
-        request.setOtp("123456");
-
-        Mockito.when(authenticationService.verifyPasswordResetOTP("email@example.com", "123456")).thenReturn(null);
-
-        mockMvc.perform(post("/api/auth/verify-reset-otp")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value("Invalid OTP"));
-    }
-
-    @Test
-    void testVerifyResetOTP_IllegalArgumentException() throws Exception {
-        VerifyResetOTPRequest request = new VerifyResetOTPRequest();
-        request.setEmail("social-login@example.com");
-        request.setOtp("123456");
-
-        // Mock the service to throw IllegalArgumentException
-        String errorMessage = "Password reset is only available for email-registered users.";
-        Mockito.when(authenticationService.verifyPasswordResetOTP("social-login@example.com", "123456"))
-                .thenThrow(new IllegalArgumentException(errorMessage));
-
-        mockMvc.perform(post("/api/auth/verify-reset-otp")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value(errorMessage))
-                .andExpect(jsonPath("$.data").doesNotExist());
-    }
-
-    @Test
-    void testResetPassword_Success() throws Exception {
-        PasswordResetWithOTPRequest request = new PasswordResetWithOTPRequest();
-        request.setEmail("email@example.com");
-        request.setNewPassword("newPassword123");
-        request.setResetToken("valid-reset-token");
-
-        Mockito.doNothing().when(authenticationService).resetPassword(
-                "email@example.com", "newPassword123", "valid-reset-token");
-
-        mockMvc.perform(post("/api/auth/reset-password")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("Password has been reset successfully"));
-    }
-
-    @Test
-    void testResetPassword_InvalidToken() throws Exception {
-        PasswordResetWithOTPRequest request = new PasswordResetWithOTPRequest();
-        request.setEmail("email@example.com");
-        request.setNewPassword("newPassword123");
-        request.setResetToken("invalid-token");
-
-        Mockito.doThrow(new InvalidCredentialsException("Invalid or expired reset token. Please request a new OTP."))
-                .when(authenticationService).resetPassword("email@example.com", "newPassword123", "invalid-token");
-
-        mockMvc.perform(post("/api/auth/reset-password")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value("Invalid or expired reset token. Please request a new OTP."));
-    }
-
-    @Test
-    void testRegisterEmail_UserAlreadyExistsException() throws Exception {
-        // Prepare registration request
-        RegistrationRequest request = new RegistrationRequest();
-        request.setEmail("existing@example.com");
-        request.setPassword("password");
-        request.setName("Test User");
-        request.setBirthdate(LocalDate.now().minusYears(20));
-
-        // Mock the service to throw UserAlreadyExistsException
-        String errorMessage = "User with email already exists";
-        Mockito.when(authenticationService.registerUser(Mockito.any(RegistrationRequest.class)))
-                .thenThrow(new UserAlreadyExistsException(errorMessage));
-
-        // Perform the POST request to /register-email endpoint
-        mockMvc.perform(post("/api/auth/register-email")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value(errorMessage))
-                .andExpect(jsonPath("$.data").doesNotExist());
-    }
-
-    @Test
-    void testDashboard() throws Exception {
-        mockMvc.perform(get("/api/auth/dashboard"))
-                .andExpect(status().isOk())
-                .andExpect(content().string("{}"));
-    }
-
-    @Test
-    void testAuthenticateGoogle_Success() throws Exception {
-        // Prepare test data
-        GoogleAuthDTO googleAuthData = new GoogleAuthDTO();
-        googleAuthData.setIdToken("validGoogleToken");
-        googleAuthData.setServerAuthCode("validServerAuthCode");
-
-        // Generate a mock JWT token
-        UUID userId = UUID.randomUUID();
-        String mockJwt = "mockJwtToken123";
-        String refreshToken = "test-refreshToken123";
-        AuthToken returnToken = new AuthToken(userId, mockJwt, refreshToken);
-
-        // Mock the service method to return the JWT token
-        Mockito.when(googleAuthService.authenticate(any(GoogleAuthDTO.class)))
-                .thenReturn(returnToken);
-
-        // Perform the test
-        mockMvc.perform(post("/api/auth/google")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(googleAuthData)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("OK"))
-                .andExpect(jsonPath("$.data.userId").value(userId.toString()))
-                .andExpect(jsonPath("$.data.accessToken").value(mockJwt))
-                .andExpect(jsonPath("$.data.refreshToken").value(refreshToken));
-    }
-
-    @Test
-    void testAuthenticateGoogle_MissingIdToken() throws Exception {
-        // Prepare test data with missing idToken
-        GoogleAuthDTO googleAuthData = new GoogleAuthDTO();
-        googleAuthData.setServerAuthCode("validServerAuthCode");
-
-        // Perform the test
-        mockMvc.perform(post("/api/auth/google")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(googleAuthData)))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void testAuthenticateGoogle_MissingServerAuthCode() throws Exception {
-        // Prepare test data with missing serverAuthCode
-        GoogleAuthDTO googleAuthData = new GoogleAuthDTO();
-        googleAuthData.setIdToken("validGoogleToken");
-
-        // Perform the test
-        mockMvc.perform(post("/api/auth/google")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(googleAuthData)))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void testAuthenticateGoogle_UserAlreadyExists() throws Exception {
-        // Prepare test data
-        GoogleAuthDTO googleAuthData = new GoogleAuthDTO();
-        googleAuthData.setIdToken("existingUserToken");
-        googleAuthData.setServerAuthCode("existingUserAuthCode");
-
-        // Simulate UserAlreadyExistsException
-        String errorMessage = "User with this email already exists";
-        Mockito.when(googleAuthService.authenticate(any(GoogleAuthDTO.class)))
-                .thenThrow(new UserAlreadyExistsException(errorMessage));
-
-        // Perform the test
-        mockMvc.perform(post("/api/auth/google")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(googleAuthData)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value(errorMessage))
-                .andExpect(jsonPath("$.data").doesNotExist());
-    }
-
-    @Test
-    void testAuthenticateGoogle_GeneralException() throws Exception {
-        // Prepare test data
-        GoogleAuthDTO googleAuthData = new GoogleAuthDTO();
-        googleAuthData.setIdToken("invalidToken");
-        googleAuthData.setServerAuthCode("invalidAuthCode");
-
-        // Simulate a general exception
-        String errorMessage = "Authentication failed: Invalid token";
-        Mockito.when(googleAuthService.authenticate(any(GoogleAuthDTO.class)))
-                .thenThrow(new RuntimeException(errorMessage));
-
-        // Perform the test
-        mockMvc.perform(post("/api/auth/google")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(googleAuthData)))
-                .andExpect(status().isInternalServerError());
-    }
-
-    @Test
-    void testAuthenticateGoogle_EmptyInput() throws Exception {
-        // Perform test with empty input
-        mockMvc.perform(post("/api/auth/google")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{}"))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void testVerifyJwtToken() throws Exception {
-        // Prepare test data
-        String validToken = "valid.jwt.token";
-
-        // Create a mock UserResponse
-        UUID userId = UUID.randomUUID();
-        UserResponse userResponse = UserResponse.builder()
-                .id(userId)
-                .name("Test User")
-                .email("test@example.com")
-                .build();
-
-        // Mock the service method to return the mocked user response
-        Mockito.when(jwtService.getUserFromJwtToken(validToken)).thenReturn(userResponse);
-
-        // Perform the test
-        mockMvc.perform(post("/api/auth/verify-jwt")
-                .param("token", validToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("OK"))
-                .andExpect(jsonPath("$.data.id").value(userId.toString()))
-                .andExpect(jsonPath("$.data.email").value("test@example.com"))
-                .andExpect(jsonPath("$.data.name").value("Test User"));
-    }
-
-    @Test
-    void testVerifyJwtToken_InvalidToken() throws Exception {
-        // Prepare test data
-        String invalidToken = "invalid.jwt.token";
-
-        // Mock the service method to throw InvalidCredentialsException
-        Mockito.when(jwtService.getUserFromJwtToken(invalidToken))
-                .thenThrow(new InvalidCredentialsException("Invalid token"));
-
-        // Perform the test
-        mockMvc.perform(post("/api/auth/verify-jwt")
-                        .param("token", invalidToken))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value("Invalid token"))
-                .andExpect(jsonPath("$.data").doesNotExist()); // No data expected in case of error
-    }
-
-    @Test
-    void renewRefreshToken_Success() throws Exception {
-        UUID userId = UUID.randomUUID();
-        String accessToken = "test-jwt";
-        String refreshToken = "test-refresh-token";
-        AuthToken returnToken = new AuthToken(userId, accessToken, refreshToken);
-        Mockito.when(authenticationService.renewRefreshToken(anyString())).thenReturn(returnToken);
-
-        mockMvc.perform(post("/api/auth/refresh-token")
-                        .param("token", "existing-token")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("OK"))
-                .andExpect(jsonPath("$.data.userId").value(userId.toString()))
-                .andExpect(jsonPath("$.data.accessToken").value(accessToken))
-                .andExpect(jsonPath("$.data.refreshToken").value(refreshToken));
-    }
-
-    @Test
-    void renewRefreshToken_InvalidToken() throws Exception {
-        Mockito.when(authenticationService.renewRefreshToken(anyString())).thenThrow(
-                new InvalidCredentialsException("Invalid refresh token"));
-
-        mockMvc.perform(post("/api/auth/refresh-token")
-                        .param("token", "invalid-token")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value("Invalid refresh token"));
-    }
-
-    @TestConfiguration
-    static class TestConfig {
-        @Bean
-        public AuthenticationService authenticationService() {
-            return Mockito.mock(AuthenticationService.class);
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Autowired
+        private AuthenticationService authenticationService;
+
+        @Autowired
+        private GoogleAuthService googleAuthService;
+
+        @Autowired
+        private JwtService jwtService;
+
+        @Autowired
+        private ObjectMapper objectMapper;
+
+        @Test
+        void testRegisterEmail() throws Exception {
+                RegistrationRequest request = new RegistrationRequest();
+                request.setEmail("email@example.com");
+                request.setPassword("password");
+                request.setName("Test User");
+                request.setBirthdate(LocalDate.now().minusYears(20));
+
+                User user = new User();
+                user.setEmail("email@example.com");
+                user.setPassword("encodedPassword");
+                user.setName("Test User");
+                user.setRole(Role.REGISTERED_USER);
+                user.setBirthdate(request.getBirthdate());
+                user.setProvider("EMAIL");
+
+                UUID userId = UUID.randomUUID();
+                user.setId(userId);
+
+                String accessToken = jwtService.generateToken(user.getId());
+                String refreshToken = "test-refresh-token";
+                AuthToken returnToken = new AuthToken(userId, accessToken, refreshToken);
+
+                Mockito.when(authenticationService.registerUser(any(RegistrationRequest.class)))
+                                .thenReturn(returnToken);
+
+                mockMvc.perform(post("/api/auth/register-email")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.success").value(true))
+                                .andExpect(jsonPath("$.message").value("OK"))
+                                .andExpect(jsonPath("$.data.userId").value(userId.toString()))
+                                .andExpect(jsonPath("$.data.accessToken").value(accessToken))
+                                .andExpect(jsonPath("$.data.refreshToken").value(refreshToken));
         }
 
-        @Bean
-        public GoogleAuthService googleAuthService() {
-            return Mockito.mock(GoogleAuthService.class);
+        @Test
+        void testLoginEmail() throws Exception {
+                User user = new User();
+                user.setEmail("email@example.com");
+                user.setPassword("encodedPassword");
+                user.setName("Test User");
+                user.setVerified(true);
+                user.setRole(Role.REGISTERED_USER);
+                user.setBirthdate(LocalDate.now().minusYears(20));
+                user.setProvider("EMAIL");
+
+                UUID userId = UUID.randomUUID();
+                user.setId(userId);
+
+                // Create LoginRequest object
+                LoginRequest loginRequest = new LoginRequest();
+                loginRequest.setEmail("email@example.com");
+                loginRequest.setPassword("password");
+
+                String accessToken = jwtService.generateToken(user.getId());
+                String refreshToken = "test-refresh-token";
+                AuthToken returnToken = new AuthToken(userId, accessToken, refreshToken);
+
+                Mockito.when(authenticationService.loginUser("email@example.com", "password")).thenReturn(returnToken);
+
+                mockMvc.perform(post("/api/auth/login-email")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(loginRequest)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.data.accessToken").value(accessToken))
+                                .andExpect(jsonPath("$.data.refreshToken").value(refreshToken));
         }
 
-        @Bean
-        public JwtService jwtService() {
-            return Mockito.mock(JwtService.class);
+        @Test
+        void testLoginEmail_InvalidCredentials() throws Exception {
+                // Prepare test data
+                String email = "email@example.com";
+                String password = "invalidPassword";
+
+                // Create LoginRequest object
+                LoginRequest loginRequest = new LoginRequest();
+                loginRequest.setEmail(email);
+                loginRequest.setPassword(password);
+
+                // Mock the service method to throw InvalidCredentialsException
+                Mockito.when(authenticationService.loginUser(email, password))
+                                .thenThrow(new InvalidCredentialsException("Invalid email or password"));
+
+                // Perform the test
+                mockMvc.perform(post("/api/auth/login-email")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(loginRequest)))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.success").value(false))
+                                .andExpect(jsonPath("$.message").value("Invalid email or password"))
+                                .andExpect(jsonPath("$.data").doesNotExist()); // No data expected in case of error
         }
 
-        @Bean
-        public RefreshTokenService refreshTokenService() {
-            return Mockito.mock(RefreshTokenService.class);
-        }
-    }
+        @Test
+        void testVerifyOTP_Success() throws Exception {
+                // Create OTPRequest object
+                OTPRequest otpRequest = new OTPRequest();
+                otpRequest.setEmail("email@example.com");
+                otpRequest.setOtp("123456");
 
-    @TestConfiguration
-    static class TestSecurityConfig {
-        @Bean
-        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-            http.csrf(AbstractHttpConfigurer::disable)
-                    .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll());
-            return http.build();
+                Mockito.when(authenticationService.verifyOTP("email@example.com", "123456")).thenReturn(true);
+
+                mockMvc.perform(post("/api/auth/verify-otp")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(otpRequest)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.success").value(true))
+                                .andExpect(jsonPath("$.message").value("User verified successfully"));
         }
-    }
+
+        @Test
+        void testVerifyOTP_Failure() throws Exception {
+                // Create OTPRequest object
+                OTPRequest otpRequest = new OTPRequest();
+                otpRequest.setEmail("email@example.com");
+                otpRequest.setOtp("000000");
+
+                Mockito.when(authenticationService.verifyOTP("email@example.com", "000000")).thenReturn(false);
+
+                mockMvc.perform(post("/api/auth/verify-otp")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(otpRequest)))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.success").value(false))
+                                .andExpect(jsonPath("$.message").value("OTP verification failed"));
+        }
+
+        @Test
+        void testVerifyOTP_InvalidCredentials() throws Exception {
+                // Create OTPRequest with invalid data
+                OTPRequest otpRequest = new OTPRequest();
+                otpRequest.setEmail("email@example.com");
+                otpRequest.setOtp("invalid");
+
+                // Just mock the service to throw the exception
+                Mockito.when(authenticationService.verifyOTP("email@example.com", "invalid"))
+                                .thenReturn(false);
+
+                // Only check that the status is 400 (Bad Request)
+                mockMvc.perform(post("/api/auth/verify-otp")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(otpRequest)))
+                                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void testForgotPassword() throws Exception {
+                PasswordResetRequest request = new PasswordResetRequest();
+                request.setEmail("email@example.com");
+
+                Mockito.doNothing().when(authenticationService).forgotPassword("email@example.com");
+
+                mockMvc.perform(post("/api/auth/forgot-password")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.success").value(true))
+                                .andExpect(jsonPath("$.message")
+                                                .value("Password reset OTP has been sent to your email"));
+        }
+
+        @Test
+        void testForgotPassword_IllegalArgumentException() throws Exception {
+                PasswordResetRequest request = new PasswordResetRequest();
+                request.setEmail("social-login@example.com");
+
+                // Mock the service to throw IllegalArgumentException
+                String errorMessage = "Password reset is only available for email-registered users.";
+                Mockito.doThrow(new IllegalArgumentException(errorMessage))
+                                .when(authenticationService).forgotPassword("social-login@example.com");
+
+                mockMvc.perform(post("/api/auth/forgot-password")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.success").value(false))
+                                .andExpect(jsonPath("$.message").value(errorMessage))
+                                .andExpect(jsonPath("$.data").doesNotExist());
+        }
+
+        @Test
+        void testVerifyResetOTP_Success() throws Exception {
+                VerifyResetOTPRequest request = new VerifyResetOTPRequest();
+                request.setEmail("email@example.com");
+                request.setOtp("123456");
+
+                Mockito.when(authenticationService.verifyPasswordResetOTP("email@example.com", "123456"))
+                                .thenReturn("reset-token-123");
+
+                mockMvc.perform(post("/api/auth/verify-reset-otp")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.success").value(true))
+                                .andExpect(jsonPath("$.message")
+                                                .value("OTP verified successfully. Reset token valid for 3 minutes."))
+                                .andExpect(jsonPath("$.data.resetToken").value("reset-token-123"));
+        }
+
+        @Test
+        void testVerifyResetOTP_Failure() throws Exception {
+                VerifyResetOTPRequest request = new VerifyResetOTPRequest();
+                request.setEmail("email@example.com");
+                request.setOtp("123456");
+
+                Mockito.when(authenticationService.verifyPasswordResetOTP("email@example.com", "123456"))
+                                .thenReturn(null);
+
+                mockMvc.perform(post("/api/auth/verify-reset-otp")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.success").value(false))
+                                .andExpect(jsonPath("$.message").value("Invalid OTP"));
+        }
+
+        @Test
+        void testVerifyResetOTP_IllegalArgumentException() throws Exception {
+                VerifyResetOTPRequest request = new VerifyResetOTPRequest();
+                request.setEmail("social-login@example.com");
+                request.setOtp("123456");
+
+                // Mock the service to throw IllegalArgumentException
+                String errorMessage = "Password reset is only available for email-registered users.";
+                Mockito.when(authenticationService.verifyPasswordResetOTP("social-login@example.com", "123456"))
+                                .thenThrow(new IllegalArgumentException(errorMessage));
+
+                mockMvc.perform(post("/api/auth/verify-reset-otp")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.success").value(false))
+                                .andExpect(jsonPath("$.message").value(errorMessage))
+                                .andExpect(jsonPath("$.data").doesNotExist());
+        }
+
+        @Test
+        void testResetPassword_Success() throws Exception {
+                PasswordResetWithOTPRequest request = new PasswordResetWithOTPRequest();
+                request.setEmail("email@example.com");
+                request.setNewPassword("newPassword123");
+                request.setResetToken("valid-reset-token");
+
+                Mockito.doNothing().when(authenticationService).resetPassword(
+                                "email@example.com", "newPassword123", "valid-reset-token");
+
+                mockMvc.perform(post("/api/auth/reset-password")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.success").value(true))
+                                .andExpect(jsonPath("$.message").value("Password has been reset successfully"));
+        }
+
+        @Test
+        void testResetPassword_InvalidToken() throws Exception {
+                PasswordResetWithOTPRequest request = new PasswordResetWithOTPRequest();
+                request.setEmail("email@example.com");
+                request.setNewPassword("newPassword123");
+                request.setResetToken("invalid-token");
+
+                Mockito.doThrow(new InvalidCredentialsException(
+                                "Invalid or expired reset token. Please request a new OTP."))
+                                .when(authenticationService)
+                                .resetPassword("email@example.com", "newPassword123", "invalid-token");
+
+                mockMvc.perform(post("/api/auth/reset-password")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.success").value(false))
+                                .andExpect(jsonPath("$.message")
+                                                .value("Invalid or expired reset token. Please request a new OTP."));
+        }
+
+        @Test
+        void testRegisterEmail_UserAlreadyExistsException() throws Exception {
+                // Prepare registration request
+                RegistrationRequest request = new RegistrationRequest();
+                request.setEmail("existing@example.com");
+                request.setPassword("password");
+                request.setName("Test User");
+                request.setBirthdate(LocalDate.now().minusYears(20));
+
+                // Mock the service to throw UserAlreadyExistsException
+                String errorMessage = "User with email already exists";
+                Mockito.when(authenticationService.registerUser(Mockito.any(RegistrationRequest.class)))
+                                .thenThrow(new UserAlreadyExistsException(errorMessage));
+
+                // Perform the POST request to /register-email endpoint
+                mockMvc.perform(post("/api/auth/register-email")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.success").value(false))
+                                .andExpect(jsonPath("$.message").value(errorMessage))
+                                .andExpect(jsonPath("$.data").doesNotExist());
+        }
+
+        @Test
+        void testRegisterEmail_PendingVerificationException() throws Exception {
+                // Prepare registration request
+                RegistrationRequest request = new RegistrationRequest();
+                request.setEmail("unverified@example.com");
+                request.setPassword("password");
+                request.setName("Unverified User");
+                request.setBirthdate(LocalDate.now().minusYears(20));
+
+                // Mock the service to throw PendingVerificationException
+                String errorMessage = "User already exists but is not verified. A new OTP has been sent.";
+                Mockito.when(authenticationService.registerUser(Mockito.any(RegistrationRequest.class)))
+                                .thenThrow(new PendingVerificationException(errorMessage));
+
+                // Perform the POST request to /register-email endpoint
+                mockMvc.perform(post("/api/auth/register-email")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isConflict()) // Expect HTTP 409 Conflict
+                                .andExpect(jsonPath("$.success").value(false))
+                                .andExpect(jsonPath("$.message").value(errorMessage))
+                                .andExpect(jsonPath("$.data").doesNotExist());
+        }
+
+        @Test
+        void testDashboard() throws Exception {
+                mockMvc.perform(get("/api/auth/dashboard"))
+                                .andExpect(status().isOk())
+                                .andExpect(content().string("{}"));
+        }
+
+        @Test
+        void testAuthenticateGoogle_Success() throws Exception {
+                // Prepare test data
+                GoogleAuthDTO googleAuthData = new GoogleAuthDTO();
+                googleAuthData.setIdToken("validGoogleToken");
+                googleAuthData.setServerAuthCode("validServerAuthCode");
+
+                // Generate a mock JWT token
+                UUID userId = UUID.randomUUID();
+                String mockJwt = "mockJwtToken123";
+                String refreshToken = "test-refreshToken123";
+                AuthToken returnToken = new AuthToken(userId, mockJwt, refreshToken);
+
+                // Mock the service method to return the JWT token
+                Mockito.when(googleAuthService.authenticate(any(GoogleAuthDTO.class)))
+                                .thenReturn(returnToken);
+
+                // Perform the test
+                mockMvc.perform(post("/api/auth/google")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(googleAuthData)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.success").value(true))
+                                .andExpect(jsonPath("$.message").value("OK"))
+                                .andExpect(jsonPath("$.data.userId").value(userId.toString()))
+                                .andExpect(jsonPath("$.data.accessToken").value(mockJwt))
+                                .andExpect(jsonPath("$.data.refreshToken").value(refreshToken));
+        }
+
+        @Test
+        void testAuthenticateGoogle_MissingIdToken() throws Exception {
+                // Prepare test data with missing idToken
+                GoogleAuthDTO googleAuthData = new GoogleAuthDTO();
+                googleAuthData.setServerAuthCode("validServerAuthCode");
+
+                // Perform the test
+                mockMvc.perform(post("/api/auth/google")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(googleAuthData)))
+                                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void testAuthenticateGoogle_MissingServerAuthCode() throws Exception {
+                // Prepare test data with missing serverAuthCode
+                GoogleAuthDTO googleAuthData = new GoogleAuthDTO();
+                googleAuthData.setIdToken("validGoogleToken");
+
+                // Perform the test
+                mockMvc.perform(post("/api/auth/google")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(googleAuthData)))
+                                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void testAuthenticateGoogle_UserAlreadyExists() throws Exception {
+                // Prepare test data
+                GoogleAuthDTO googleAuthData = new GoogleAuthDTO();
+                googleAuthData.setIdToken("existingUserToken");
+                googleAuthData.setServerAuthCode("existingUserAuthCode");
+
+                // Simulate UserAlreadyExistsException
+                String errorMessage = "User with this email already exists";
+                Mockito.when(googleAuthService.authenticate(any(GoogleAuthDTO.class)))
+                                .thenThrow(new UserAlreadyExistsException(errorMessage));
+
+                // Perform the test
+                mockMvc.perform(post("/api/auth/google")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(googleAuthData)))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.success").value(false))
+                                .andExpect(jsonPath("$.message").value(errorMessage))
+                                .andExpect(jsonPath("$.data").doesNotExist());
+        }
+
+        @Test
+        void testAuthenticateGoogle_GeneralException() throws Exception {
+                // Prepare test data
+                GoogleAuthDTO googleAuthData = new GoogleAuthDTO();
+                googleAuthData.setIdToken("invalidToken");
+                googleAuthData.setServerAuthCode("invalidAuthCode");
+
+                // Simulate a general exception
+                String errorMessage = "Authentication failed: Invalid token";
+                Mockito.when(googleAuthService.authenticate(any(GoogleAuthDTO.class)))
+                                .thenThrow(new RuntimeException(errorMessage));
+
+                // Perform the test
+                mockMvc.perform(post("/api/auth/google")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(googleAuthData)))
+                                .andExpect(status().isInternalServerError());
+        }
+
+        @Test
+        void testAuthenticateGoogle_EmptyInput() throws Exception {
+                // Perform test with empty input
+                mockMvc.perform(post("/api/auth/google")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{}"))
+                                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void testVerifyJwtToken() throws Exception {
+                // Prepare test data
+                String validToken = "valid.jwt.token";
+
+                // Create a mock UserResponse
+                UUID userId = UUID.randomUUID();
+                UserResponse userResponse = UserResponse.builder()
+                                .id(userId)
+                                .name("Test User")
+                                .email("test@example.com")
+                                .build();
+
+                // Mock the service method to return the mocked user response
+                Mockito.when(jwtService.getUserFromJwtToken(validToken)).thenReturn(userResponse);
+
+                // Perform the test
+                mockMvc.perform(post("/api/auth/verify-jwt")
+                                .param("token", validToken))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.success").value(true))
+                                .andExpect(jsonPath("$.message").value("OK"))
+                                .andExpect(jsonPath("$.data.id").value(userId.toString()))
+                                .andExpect(jsonPath("$.data.email").value("test@example.com"))
+                                .andExpect(jsonPath("$.data.name").value("Test User"));
+        }
+
+        @Test
+        void testVerifyJwtToken_InvalidToken() throws Exception {
+                // Prepare test data
+                String invalidToken = "invalid.jwt.token";
+
+                // Mock the service method to throw InvalidCredentialsException
+                Mockito.when(jwtService.getUserFromJwtToken(invalidToken))
+                                .thenThrow(new InvalidCredentialsException("Invalid token"));
+
+                // Perform the test
+                mockMvc.perform(post("/api/auth/verify-jwt")
+                                .param("token", invalidToken))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.success").value(false))
+                                .andExpect(jsonPath("$.message").value("Invalid token"))
+                                .andExpect(jsonPath("$.data").doesNotExist()); // No data expected in case of error
+        }
+
+        @Test
+        void renewRefreshToken_Success() throws Exception {
+                UUID userId = UUID.randomUUID();
+                String accessToken = "test-jwt";
+                String refreshToken = "test-refresh-token";
+                AuthToken returnToken = new AuthToken(userId, accessToken, refreshToken);
+                Mockito.when(authenticationService.renewRefreshToken(anyString())).thenReturn(returnToken);
+
+                mockMvc.perform(post("/api/auth/refresh-token")
+                                .param("token", "existing-token")
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.success").value(true))
+                                .andExpect(jsonPath("$.message").value("OK"))
+                                .andExpect(jsonPath("$.data.userId").value(userId.toString()))
+                                .andExpect(jsonPath("$.data.accessToken").value(accessToken))
+                                .andExpect(jsonPath("$.data.refreshToken").value(refreshToken));
+        }
+
+        @Test
+        void renewRefreshToken_InvalidToken() throws Exception {
+                Mockito.when(authenticationService.renewRefreshToken(anyString())).thenThrow(
+                                new InvalidCredentialsException("Invalid refresh token"));
+
+                mockMvc.perform(post("/api/auth/refresh-token")
+                                .param("token", "invalid-token")
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.success").value(false))
+                                .andExpect(jsonPath("$.message").value("Invalid refresh token"));
+        }
+
+        @TestConfiguration
+        static class TestConfig {
+                @Bean
+                public AuthenticationService authenticationService() {
+                        return Mockito.mock(AuthenticationService.class);
+                }
+
+                @Bean
+                public GoogleAuthService googleAuthService() {
+                        return Mockito.mock(GoogleAuthService.class);
+                }
+
+                @Bean
+                public JwtService jwtService() {
+                        return Mockito.mock(JwtService.class);
+                }
+
+                @Bean
+                public RefreshTokenService refreshTokenService() {
+                        return Mockito.mock(RefreshTokenService.class);
+                }
+        }
+
+        @TestConfiguration
+        static class TestSecurityConfig {
+                @Bean
+                public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                        http.csrf(AbstractHttpConfigurer::disable)
+                                        .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll());
+                        return http.build();
+                }
+        }
 }

--- a/src/test/java/com/safetypin/authentication/controller/ProfileControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/ProfileControllerTest.java
@@ -1,10 +1,22 @@
 package com.safetypin.authentication.controller;
 
-import com.safetypin.authentication.dto.*;
-import com.safetypin.authentication.exception.InvalidCredentialsException;
-import com.safetypin.authentication.exception.ResourceNotFoundException;
-import com.safetypin.authentication.service.JwtService;
-import com.safetypin.authentication.service.ProfileService;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,474 +26,504 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import com.safetypin.authentication.dto.AuthResponse;
+import com.safetypin.authentication.dto.PostedByData;
+import com.safetypin.authentication.dto.ProfileResponse;
+import com.safetypin.authentication.dto.ProfileViewDTO;
+import com.safetypin.authentication.dto.UpdateProfileRequest;
+import com.safetypin.authentication.dto.UserResponse;
+import com.safetypin.authentication.exception.InvalidCredentialsException;
+import com.safetypin.authentication.exception.ResourceNotFoundException;
+import com.safetypin.authentication.service.JwtService;
+import com.safetypin.authentication.service.ProfileService;
 
 @ExtendWith(MockitoExtension.class)
 class ProfileControllerTest {
 
-    @Mock
-    private ProfileService profileService;
-
-    @Mock
-    private JwtService jwtService;
-
-    @InjectMocks
-    private ProfileController profileController;
-
-    private UUID testUserId;
-    private ProfileResponse testProfileResponse;
-    private UpdateProfileRequest testUpdateRequest;
-    private String testAuthHeader;
-
-    @BeforeEach
-    void setUp() {
-        testUserId = UUID.randomUUID();
-        String testToken = "test-token";
-        testAuthHeader = "Bearer " + testToken;
-
-        // Set up test user response from JWT
-        UserResponse testUserResponse = UserResponse.builder()
-                .id(testUserId)
-                .name("testuser")
-                .email("test@example.com")
-                .build();
-
-        // Set up test profile response
-        testProfileResponse = ProfileResponse.builder()
-                .id(testUserId)
-                .role("USER")
-                .isVerified(true)
-                .instagram("testuser")
-                .twitter("testuser")
-                .line("testuser")
-                .tiktok("testuser")
-                .discord("testuser#1234")
-                .build();
-
-        // Set up test update request - using setters instead of builder
-        testUpdateRequest = new UpdateProfileRequest();
-        testUpdateRequest.setInstagram("newuser");
-        testUpdateRequest.setTwitter("newuser");
-        testUpdateRequest.setLine("newuser");
-        testUpdateRequest.setTiktok("newuser");
-        testUpdateRequest.setDiscord("newuser#5678");
-        testUpdateRequest.setProfilePicture("https://example.com/profile.jpg");
-        testUpdateRequest.setProfileBanner("https://example.com/banner.jpg");
-
-        // Configure JWT service mock
-        // (lenient since some tests don't parse the token)
-        lenient().when(jwtService.getUserFromJwtToken(testToken)).thenReturn(testUserResponse);
-    }
-
-    // GET PROFILE TESTS
-
-    @Test
-    void getProfile_Success() {
-        // Arrange
-        when(profileService.getProfile(testUserId, testUserId)).thenReturn(testProfileResponse);
-
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId, testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertTrue(body.isSuccess());
-        assertEquals("Profile retrieved successfully", body.getMessage());
-        assertEquals(testProfileResponse, body.getData());
-    }
-
-    @Test
-    void getProfile_NotFound() {
-        // Arrange
-        when(profileService.getProfile(testUserId, testUserId))
-                .thenThrow(new ResourceNotFoundException("User not found with id " + testUserId));
-
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId, testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals("User not found with id " + testUserId, body.getMessage());
-        assertNull(body.getData());
-    }
-
-    @Test
-    void getProfile_InternalServerError() {
-        // Arrange
-        String errorMessage = "Database connection error";
-        when(profileService.getProfile(testUserId, testUserId))
-                .thenThrow(new RuntimeException(errorMessage));
-
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId, testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals("Error retrieving profile: " + errorMessage, body.getMessage());
-        assertNull(body.getData());
-    }
-
-    // GET MY PROFILE TESTS
-
-    @Test
-    void getMyProfile_Success() {
-        // Arrange
-        when(profileService.getProfile(testUserId, testUserId)).thenReturn(testProfileResponse);
-
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertTrue(body.isSuccess());
-        assertEquals("Profile retrieved successfully", body.getMessage());
-        assertEquals(testProfileResponse, body.getData());
-    }
-
-    @Test
-    void getMyProfile_Unauthorized() {
-        // Arrange
-        String invalidToken = "invalid-token";
-        String invalidAuthToken = "Bearer " + invalidToken;
-        when(jwtService.getUserFromJwtToken(invalidToken))
-                .thenThrow(new RuntimeException("Invalid token"));
-
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getMyProfile(invalidAuthToken);
-
-        // Assert
-        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals("Invalid token", body.getMessage());
-        assertNull(body.getData());
-    }
-
-    @Test
-    void getMyProfile_NotFound() {
-        // Arrange
-        when(profileService.getProfile(testUserId, testUserId))
-                .thenThrow(new ResourceNotFoundException("User not found with id " + testUserId));
-
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals("User not found with id " + testUserId, body.getMessage());
-        assertNull(body.getData());
-    }
-
-    @Test
-    void getMyProfile_InternalServerError() {
-        // Arrange
-        String errorMessage = "Database connection error";
-        when(profileService.getProfile(testUserId, testUserId))
-                .thenThrow(new RuntimeException(errorMessage));
-
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals("Error retrieving profile: " + errorMessage, body.getMessage());
-        assertNull(body.getData());
-    }
-
-    // UPDATE MY PROFILE TESTS
-
-    @Test
-    void updateMyProfile_Success() {
-        // Arrange
-        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class)))
-                .thenReturn(testProfileResponse);
-
-        // Act
-        ResponseEntity<AuthResponse> response =
-                profileController.updateMyProfile(testUpdateRequest, testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertTrue(body.isSuccess());
-        assertEquals("Profile updated successfully", body.getMessage());
-        assertEquals(testProfileResponse, body.getData());
-    }
-
-    @Test
-    void updateMyProfile_Unauthorized() {
-        // Arrange
-        String errorMessage = "You are not authorized to update this profile";
-        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class)))
-                .thenThrow(new InvalidCredentialsException(errorMessage));
-
-        // Act
-        ResponseEntity<AuthResponse> response =
-                profileController.updateMyProfile(testUpdateRequest, testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals(errorMessage, body.getMessage());
-        assertNull(body.getData());
-    }
-
-    @Test
-    void updateMyProfile_WrongToken() {
-        // Arrange
-        String errorMessage = "Token expired";
-        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class)))
-                .thenThrow(new InvalidCredentialsException(errorMessage));
-
-        // Act
-        ResponseEntity<AuthResponse> response =
-                profileController.updateMyProfile(testUpdateRequest, testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals(errorMessage, body.getMessage());
-        assertNull(body.getData());
-    }
-
-    @Test
-    void updateMyProfile_NotFound() {
-        // Arrange
-        String errorMessage = "User not found with id " + testUserId;
-        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class)))
-                .thenThrow(new ResourceNotFoundException(errorMessage));
-
-        // Act
-        ResponseEntity<AuthResponse> response =
-                profileController.updateMyProfile(testUpdateRequest, testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals(errorMessage, body.getMessage());
-        assertNull(body.getData());
-    }
-
-    @Test
-    void updateMyProfile_InternalServerError() {
-        // Arrange
-        String errorMessage = "Database update failed";
-        when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class)))
-                .thenThrow(new RuntimeException(errorMessage));
-
-        // Act
-        ResponseEntity<AuthResponse> response =
-                profileController.updateMyProfile(testUpdateRequest, testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals("Error updating profile: " + errorMessage, body.getMessage());
-        assertNull(body.getData());
-    }
-
-    // GET USERS BATCH TEST
-
-    @Test
-    void getUsersBatch_Success() {
-        // Arrange
-        List<UUID> userIds = Arrays.asList(UUID.randomUUID(), UUID.randomUUID());
-        // Create PostedByData instances using the builder
-        PostedByData user1Data = PostedByData.builder()
-                .userId(userIds.get(0))
-                .name("User1")
-                .profilePicture("pic1.jpg")
-                .build();
-        PostedByData user2Data = PostedByData.builder()
-                .userId(userIds.get(1))
-                .name("User2")
-                .profilePicture("pic2.jpg")
-                .build();
-        Map<UUID, PostedByData> expectedResponse = Map.of(
-                userIds.get(0), user1Data,
-                userIds.get(1), user2Data);
-
-        when(profileService.getUsersBatch(userIds)).thenReturn(expectedResponse);
-
-        // Act
-        Map<UUID, PostedByData> response = profileController.getUsersBatch(userIds);
-
-        // Assert
-        assertNotNull(response);
-        assertEquals(expectedResponse, response);
-        assertEquals(2, response.size());
-    }
-
-    // AUTHENTICATED PROFILE VIEW TESTS
-
-    @Test
-    void getProfile_AuthenticatedSuccess() {
-        // Arrange
-        UUID viewerId = testUserId;
-        UUID profileId = UUID.randomUUID();
-        when(profileService.getProfile(profileId, viewerId)).thenReturn(testProfileResponse);
-
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getProfile(profileId, testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertTrue(body.isSuccess());
-        assertEquals("Profile retrieved successfully", body.getMessage());
-        assertEquals(testProfileResponse, body.getData());
-    }
-
-    @Test
-    void getProfile_FailedAuthenticationDoesNotAffectOutput() {
-        // Arrange
-        String invalidAuthHeader = "Bearer invalid-token";
-        UUID profileId = UUID.randomUUID();
-        when(jwtService.getUserFromJwtToken("invalid-token"))
-                .thenThrow(new InvalidCredentialsException("Invalid token"));
-        when(profileService.getProfile(profileId, null)).thenReturn(testProfileResponse);
-
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getProfile(profileId, invalidAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertTrue(body.isSuccess());
-        assertEquals("Profile retrieved successfully", body.getMessage());
-        assertEquals(testProfileResponse, body.getData());
-        // Verify that profileService.getProfile was called with null viewerId
-        verify(profileService).getProfile(profileId, null);
-    }
-
-    // PROFILE VIEWS TESTS
-
-    @Test
-    void getProfileViews_Success() {
-        // Arrange
-        List<ProfileViewDTO> testViews = Arrays.asList(
-                ProfileViewDTO.builder()
-                        .viewerUserId(UUID.randomUUID())
-                        .name("Viewer 1")
-                        .profilePicture("pic1.jpg")
-                        .viewedAt(LocalDateTime.now())
-                        .build(),
-                ProfileViewDTO.builder()
-                        .viewerUserId(UUID.randomUUID())
-                        .name("Viewer 2")
-                        .profilePicture("pic2.jpg")
-                        .viewedAt(LocalDateTime.now())
-                        .build()
-        );
-
-        when(profileService.getProfileViews(testUserId)).thenReturn(testViews);
-
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getProfileViews(testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertTrue(body.isSuccess());
-        assertEquals("Profile views retrieved successfully", body.getMessage());
-        assertEquals(testViews, body.getData());
-    }
-
-    @Test
-    void getProfileViews_Unauthorized() {
-        // Arrange
-        String errorMessage = "You need to be a premium user to view profile views.";
-        when(profileService.getProfileViews(testUserId))
-                .thenThrow(new InvalidCredentialsException(errorMessage));
-
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getProfileViews(testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals(errorMessage, body.getMessage());
-        assertNull(body.getData());
-    }
-
-    @Test
-    void getProfileViews_NotFound() {
-        // Arrange
-        String errorMessage = "User not found";
-        when(profileService.getProfileViews(testUserId))
-                .thenThrow(new ResourceNotFoundException(errorMessage));
-
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getProfileViews(testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertEquals(errorMessage, body.getMessage());
-        assertNull(body.getData());
-    }
-
-    @Test
-    void getProfileViews_InternalServerError() {
-        // Arrange
-        String errorMessage = "Database update failed";
-        when(profileService.getProfileViews(testUserId))
-                .thenThrow(new RuntimeException(errorMessage));
-
-        // Act
-        ResponseEntity<AuthResponse> response = profileController.getProfileViews(testAuthHeader);
-
-        // Assert
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
-        AuthResponse body = response.getBody();
-        assertNotNull(body);
-        assertFalse(body.isSuccess());
-        assertTrue(body.getMessage().contains("Error retrieving profile views:"));
-        assertTrue(body.getMessage().contains(errorMessage));
-        assertNull(body.getData());
-    }
+        @Mock
+        private ProfileService profileService;
+
+        @Mock
+        private JwtService jwtService;
+
+        @InjectMocks
+        private ProfileController profileController;
+
+        private UUID testUserId;
+        private ProfileResponse testProfileResponse;
+        private UpdateProfileRequest testUpdateRequest;
+        private String testAuthHeader;
+
+        @BeforeEach
+        void setUp() {
+                testUserId = UUID.randomUUID();
+                String testToken = "test-token";
+                testAuthHeader = "Bearer " + testToken;
+
+                // Set up test user response from JWT
+                UserResponse testUserResponse = UserResponse.builder()
+                                .id(testUserId)
+                                .name("testuser")
+                                .email("test@example.com")
+                                .build();
+
+                // Set up test profile response
+                testProfileResponse = ProfileResponse.builder()
+                                .id(testUserId)
+                                .role("USER")
+                                .isVerified(true)
+                                .instagram("testuser")
+                                .twitter("testuser")
+                                .line("testuser")
+                                .tiktok("testuser")
+                                .discord("testuser#1234")
+                                .build();
+
+                // Set up test update request - using setters instead of builder
+                testUpdateRequest = new UpdateProfileRequest();
+                testUpdateRequest.setInstagram("newuser");
+                testUpdateRequest.setTwitter("newuser");
+                testUpdateRequest.setLine("newuser");
+                testUpdateRequest.setTiktok("newuser");
+                testUpdateRequest.setDiscord("newuser#5678");
+                testUpdateRequest.setProfilePicture("https://example.com/profile.jpg");
+                testUpdateRequest.setProfileBanner("https://example.com/banner.jpg");
+
+                // Configure JWT service mock
+                // (lenient since some tests don't parse the token)
+                lenient().when(jwtService.getUserFromJwtToken(testToken)).thenReturn(testUserResponse);
+        }
+
+        // GET PROFILE TESTS
+
+        @Test
+        void getProfile_Success() {
+                // Arrange
+                when(profileService.getProfile(testUserId, testUserId)).thenReturn(testProfileResponse);
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId, testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertTrue(body.isSuccess());
+                assertEquals("Profile retrieved successfully", body.getMessage());
+                assertEquals(testProfileResponse, body.getData());
+        }
+
+        @Test
+        void getProfile_NotFound() {
+                // Arrange
+                when(profileService.getProfile(testUserId, testUserId))
+                                .thenThrow(new ResourceNotFoundException("User not found with id " + testUserId));
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId, testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals("User not found with id " + testUserId, body.getMessage());
+                assertNull(body.getData());
+        }
+
+        @Test
+        void getProfile_InternalServerError() {
+                // Arrange
+                String errorMessage = "Database connection error";
+                when(profileService.getProfile(testUserId, testUserId))
+                                .thenThrow(new RuntimeException(errorMessage));
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getProfile(testUserId, testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals("Error retrieving profile: " + errorMessage, body.getMessage());
+                assertNull(body.getData());
+        }
+
+        // GET MY PROFILE TESTS
+
+        @Test
+        void getMyProfile_Success() {
+                // Arrange
+                when(profileService.getProfile(testUserId, testUserId)).thenReturn(testProfileResponse);
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertTrue(body.isSuccess());
+                assertEquals("Profile retrieved successfully", body.getMessage());
+                assertEquals(testProfileResponse, body.getData());
+        }
+
+        @Test
+        void getMyProfile_Unauthorized() {
+                // Arrange
+                String invalidToken = "invalid-token";
+                String invalidAuthToken = "Bearer " + invalidToken;
+                when(jwtService.getUserFromJwtToken(invalidToken))
+                                .thenThrow(new RuntimeException("Invalid token"));
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getMyProfile(invalidAuthToken);
+
+                // Assert
+                assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals("Invalid token", body.getMessage());
+                assertNull(body.getData());
+        }
+
+        @Test
+        void getMyProfile_NotFound() {
+                // Arrange
+                when(profileService.getProfile(testUserId, testUserId))
+                                .thenThrow(new ResourceNotFoundException("User not found with id " + testUserId));
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals("User not found with id " + testUserId, body.getMessage());
+                assertNull(body.getData());
+        }
+
+        @Test
+        void getMyProfile_InternalServerError() {
+                // Arrange
+                String errorMessage = "Database connection error";
+                when(profileService.getProfile(testUserId, testUserId))
+                                .thenThrow(new RuntimeException(errorMessage));
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getMyProfile(testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals("Error retrieving profile: " + errorMessage, body.getMessage());
+                assertNull(body.getData());
+        }
+
+        // UPDATE MY PROFILE TESTS
+
+        @Test
+        void updateMyProfile_Success() {
+                // Arrange
+                when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class)))
+                                .thenReturn(testProfileResponse);
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
+                                testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertTrue(body.isSuccess());
+                assertEquals("Profile updated successfully", body.getMessage());
+                assertEquals(testProfileResponse, body.getData());
+        }
+
+        @Test
+        void updateMyProfile_Unauthorized() {
+                // Arrange
+                String errorMessage = "You are not authorized to update this profile";
+                when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class)))
+                                .thenThrow(new InvalidCredentialsException(errorMessage));
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
+                                testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals(errorMessage, body.getMessage());
+                assertNull(body.getData());
+        }
+
+        @Test
+        void updateMyProfile_WrongToken() {
+                // Arrange
+                String errorMessage = "Token expired";
+                when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class)))
+                                .thenThrow(new InvalidCredentialsException(errorMessage));
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
+                                testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals(errorMessage, body.getMessage());
+                assertNull(body.getData());
+        }
+
+        @Test
+        void updateMyProfile_NotFound() {
+                // Arrange
+                String errorMessage = "User not found with id " + testUserId;
+                when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class)))
+                                .thenThrow(new ResourceNotFoundException(errorMessage));
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
+                                testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals(errorMessage, body.getMessage());
+                assertNull(body.getData());
+        }
+
+        @Test
+        void updateMyProfile_InternalServerError() {
+                // Arrange
+                String errorMessage = "Database update failed";
+                when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class)))
+                                .thenThrow(new RuntimeException(errorMessage));
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.updateMyProfile(testUpdateRequest,
+                                testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals("Error updating profile: " + errorMessage, body.getMessage());
+                assertNull(body.getData());
+        }
+
+        @Test
+        void updateMyProfile_WithNameField_Success() {
+                // Arrange
+                UpdateProfileRequest nameUpdateRequest = new UpdateProfileRequest();
+                nameUpdateRequest.setName("Updated User Name");
+
+                ProfileResponse updatedProfileResponse = ProfileResponse.builder()
+                                .id(testUserId)
+                                .name("Updated User Name")
+                                .role("USER")
+                                .isVerified(true)
+                                .instagram("testuser")
+                                .twitter("testuser")
+                                .build();
+
+                when(profileService.updateProfile(eq(testUserId), any(UpdateProfileRequest.class)))
+                                .thenReturn(updatedProfileResponse);
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.updateMyProfile(nameUpdateRequest,
+                                testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertTrue(body.isSuccess());
+                assertEquals("Profile updated successfully", body.getMessage());
+
+                ProfileResponse returnedProfile = (ProfileResponse) body.getData();
+                assertEquals("Updated User Name", returnedProfile.getName());
+        }
+
+        // GET USERS BATCH TEST
+
+        @Test
+        void getUsersBatch_Success() {
+                // Arrange
+                List<UUID> userIds = Arrays.asList(UUID.randomUUID(), UUID.randomUUID());
+                // Create PostedByData instances using the builder
+                PostedByData user1Data = PostedByData.builder()
+                                .userId(userIds.get(0))
+                                .name("User1")
+                                .profilePicture("pic1.jpg")
+                                .build();
+                PostedByData user2Data = PostedByData.builder()
+                                .userId(userIds.get(1))
+                                .name("User2")
+                                .profilePicture("pic2.jpg")
+                                .build();
+                Map<UUID, PostedByData> expectedResponse = Map.of(
+                                userIds.get(0), user1Data,
+                                userIds.get(1), user2Data);
+
+                when(profileService.getUsersBatch(userIds)).thenReturn(expectedResponse);
+
+                // Act
+                Map<UUID, PostedByData> response = profileController.getUsersBatch(userIds);
+
+                // Assert
+                assertNotNull(response);
+                assertEquals(expectedResponse, response);
+                assertEquals(2, response.size());
+        }
+
+        // AUTHENTICATED PROFILE VIEW TESTS
+
+        @Test
+        void getProfile_AuthenticatedSuccess() {
+                // Arrange
+                UUID viewerId = testUserId;
+                UUID profileId = UUID.randomUUID();
+                when(profileService.getProfile(profileId, viewerId)).thenReturn(testProfileResponse);
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getProfile(profileId, testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertTrue(body.isSuccess());
+                assertEquals("Profile retrieved successfully", body.getMessage());
+                assertEquals(testProfileResponse, body.getData());
+        }
+
+        @Test
+        void getProfile_FailedAuthenticationDoesNotAffectOutput() {
+                // Arrange
+                String invalidAuthHeader = "Bearer invalid-token";
+                UUID profileId = UUID.randomUUID();
+                when(jwtService.getUserFromJwtToken("invalid-token"))
+                                .thenThrow(new InvalidCredentialsException("Invalid token"));
+                when(profileService.getProfile(profileId, null)).thenReturn(testProfileResponse);
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getProfile(profileId, invalidAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertTrue(body.isSuccess());
+                assertEquals("Profile retrieved successfully", body.getMessage());
+                assertEquals(testProfileResponse, body.getData());
+                // Verify that profileService.getProfile was called with null viewerId
+                verify(profileService).getProfile(profileId, null);
+        }
+
+        // PROFILE VIEWS TESTS
+
+        @Test
+        void getProfileViews_Success() {
+                // Arrange
+                List<ProfileViewDTO> testViews = Arrays.asList(
+                                ProfileViewDTO.builder()
+                                                .viewerUserId(UUID.randomUUID())
+                                                .name("Viewer 1")
+                                                .profilePicture("pic1.jpg")
+                                                .viewedAt(LocalDateTime.now())
+                                                .build(),
+                                ProfileViewDTO.builder()
+                                                .viewerUserId(UUID.randomUUID())
+                                                .name("Viewer 2")
+                                                .profilePicture("pic2.jpg")
+                                                .viewedAt(LocalDateTime.now())
+                                                .build());
+
+                when(profileService.getProfileViews(testUserId)).thenReturn(testViews);
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getProfileViews(testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.OK, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertTrue(body.isSuccess());
+                assertEquals("Profile views retrieved successfully", body.getMessage());
+                assertEquals(testViews, body.getData());
+        }
+
+        @Test
+        void getProfileViews_Unauthorized() {
+                // Arrange
+                String errorMessage = "You need to be a premium user to view profile views.";
+                when(profileService.getProfileViews(testUserId))
+                                .thenThrow(new InvalidCredentialsException(errorMessage));
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getProfileViews(testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals(errorMessage, body.getMessage());
+                assertNull(body.getData());
+        }
+
+        @Test
+        void getProfileViews_NotFound() {
+                // Arrange
+                String errorMessage = "User not found";
+                when(profileService.getProfileViews(testUserId))
+                                .thenThrow(new ResourceNotFoundException(errorMessage));
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getProfileViews(testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertEquals(errorMessage, body.getMessage());
+                assertNull(body.getData());
+        }
+
+        @Test
+        void getProfileViews_InternalServerError() {
+                // Arrange
+                String errorMessage = "Database update failed";
+                when(profileService.getProfileViews(testUserId))
+                                .thenThrow(new RuntimeException(errorMessage));
+
+                // Act
+                ResponseEntity<AuthResponse> response = profileController.getProfileViews(testAuthHeader);
+
+                // Assert
+                assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+                AuthResponse body = response.getBody();
+                assertNotNull(body);
+                assertFalse(body.isSuccess());
+                assertTrue(body.getMessage().contains("Error retrieving profile views:"));
+                assertTrue(body.getMessage().contains(errorMessage));
+                assertNull(body.getData());
+        }
 }

--- a/src/test/java/com/safetypin/authentication/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/safetypin/authentication/service/AuthenticationServiceTest.java
@@ -1,12 +1,23 @@
 package com.safetypin.authentication.service;
 
-import com.safetypin.authentication.dto.AuthToken;
-import com.safetypin.authentication.dto.RegistrationRequest;
-import com.safetypin.authentication.exception.InvalidCredentialsException;
-import com.safetypin.authentication.exception.UserAlreadyExistsException;
-import com.safetypin.authentication.model.RefreshToken;
-import com.safetypin.authentication.model.Role;
-import com.safetypin.authentication.model.User;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,14 +25,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import java.time.LocalDate;
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import com.safetypin.authentication.dto.AuthToken;
+import com.safetypin.authentication.dto.RegistrationRequest;
+import com.safetypin.authentication.exception.InvalidCredentialsException;
+import com.safetypin.authentication.exception.UserAlreadyExistsException;
+import com.safetypin.authentication.model.RefreshToken;
+import com.safetypin.authentication.model.Role;
+import com.safetypin.authentication.model.User;
 
 @ExtendWith(MockitoExtension.class)
 class AuthenticationServiceTest {
@@ -60,9 +70,8 @@ class AuthenticationServiceTest {
         // set birthdate to 15 years old
         request.setBirthdate(LocalDate.now().minusYears(15));
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () ->
-                authenticationService.registerUser(request)
-        );
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> authenticationService.registerUser(request));
         assertEquals("User must be at least 16 years old", exception.getMessage());
     }
 
@@ -77,10 +86,34 @@ class AuthenticationServiceTest {
         User existingUser = new User();
         when(userService.findByEmail("test@example.com")).thenReturn(Optional.of(existingUser));
 
-        Exception exception = assertThrows(UserAlreadyExistsException.class, () ->
-                authenticationService.registerUser(request)
-        );
+        Exception exception = assertThrows(UserAlreadyExistsException.class,
+                () -> authenticationService.registerUser(request));
         assertTrue(exception.getMessage().contains("Email address is already registered"));
+    }
+
+    @Test
+    void testRegisterUser_NameTooLong() {
+        // Create a name that's 101 characters long
+        StringBuilder longName = new StringBuilder();
+        for (int i = 0; i < 101; i++) {
+            longName.append("a");
+        }
+
+        RegistrationRequest request = new RegistrationRequest();
+        request.setEmail("test@example.com");
+        request.setPassword("password");
+        request.setName(longName.toString());
+        request.setBirthdate(LocalDate.now().minusYears(20));
+
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> authenticationService.registerUser(request));
+        assertEquals("Name must not exceed 100 characters", exception.getMessage());
+
+        // Verify that no interactions with other services occurred
+        verify(userService, never()).findByEmail(anyString());
+        verify(userService, never()).save(any(User.class));
+        verify(passwordEncoder, never()).encode(anyString());
+        verify(otpService, never()).generateOTP(anyString());
     }
 
     @Test
@@ -130,9 +163,8 @@ class AuthenticationServiceTest {
     void testLoginUser_EmailNotFound() {
         when(userService.findByEmail("notfound@example.com")).thenReturn(Optional.empty());
 
-        Exception exception = assertThrows(InvalidCredentialsException.class, () ->
-                authenticationService.loginUser("notfound@example.com", "password")
-        );
+        Exception exception = assertThrows(InvalidCredentialsException.class,
+                () -> authenticationService.loginUser("notfound@example.com", "password"));
 
         assertEquals("Invalid email", exception.getMessage());
     }
@@ -151,9 +183,8 @@ class AuthenticationServiceTest {
         when(userService.findByEmail("test@example.com")).thenReturn(Optional.of(user));
         when(passwordEncoder.matches("wrongPassword", "encodedPassword")).thenReturn(false);
 
-        Exception exception = assertThrows(InvalidCredentialsException.class, () ->
-                authenticationService.loginUser("test@example.com", "wrongPassword")
-        );
+        Exception exception = assertThrows(InvalidCredentialsException.class,
+                () -> authenticationService.loginUser("test@example.com", "wrongPassword"));
 
         assertEquals("Invalid password", exception.getMessage());
     }
@@ -259,9 +290,8 @@ class AuthenticationServiceTest {
     void testForgotPassword_UserNotFound() {
         when(userService.findByEmail("notfound@example.com")).thenReturn(Optional.empty());
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () ->
-                authenticationService.forgotPassword("notfound@example.com")
-        );
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> authenticationService.forgotPassword("notfound@example.com"));
 
         assertTrue(exception.getMessage().contains("Password reset is only available for email-registered users"));
     }
@@ -279,9 +309,8 @@ class AuthenticationServiceTest {
 
         when(userService.findByEmail("social@example.com")).thenReturn(Optional.of(user));
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () ->
-                authenticationService.forgotPassword("social@example.com")
-        );
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> authenticationService.forgotPassword("social@example.com"));
 
         assertTrue(exception.getMessage().contains("Password reset is only available for email-registered users"));
     }
@@ -318,9 +347,8 @@ class AuthenticationServiceTest {
     void testVerifyPasswordResetOTP_UserNotFound() {
         when(userService.findByEmail("nonexistent@example.com")).thenReturn(Optional.empty());
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () ->
-                authenticationService.verifyPasswordResetOTP("nonexistent@example.com", "123456")
-        );
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> authenticationService.verifyPasswordResetOTP("nonexistent@example.com", "123456"));
 
         assertTrue(exception.getMessage().contains("Password reset is only available for email-registered users"));
         verify(otpService, never()).verifyOTP(anyString(), anyString());
@@ -334,9 +362,8 @@ class AuthenticationServiceTest {
 
         when(userService.findByEmail("social@example.com")).thenReturn(Optional.of(user));
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () ->
-                authenticationService.verifyPasswordResetOTP("social@example.com", "123456")
-        );
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> authenticationService.verifyPasswordResetOTP("social@example.com", "123456"));
 
         assertTrue(exception.getMessage().contains("Password reset is only available for email-registered users"));
         verify(otpService, never()).verifyOTP(anyString(), anyString());
@@ -350,9 +377,8 @@ class AuthenticationServiceTest {
 
         when(userService.findByEmail("social@example.com")).thenReturn(Optional.of(user));
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () ->
-                authenticationService.resetPassword("social@example.com", "newPassword", "reset-token")
-        );
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> authenticationService.resetPassword("social@example.com", "newPassword", "reset-token"));
 
         assertTrue(exception.getMessage().contains("Password reset is only available for email-registered users"));
         verify(userService, never()).save(any(User.class));
@@ -384,9 +410,8 @@ class AuthenticationServiceTest {
         when(userService.findByEmail("test@example.com")).thenReturn(Optional.of(user));
         when(otpService.verifyResetToken("invalid-token", "test@example.com")).thenReturn(false);
 
-        assertThrows(InvalidCredentialsException.class, () ->
-                authenticationService.resetPassword("test@example.com", "newPassword", "invalid-token")
-        );
+        assertThrows(InvalidCredentialsException.class,
+                () -> authenticationService.resetPassword("test@example.com", "newPassword", "invalid-token"));
 
         verify(userService, never()).save(any(User.class));
     }
@@ -399,9 +424,8 @@ class AuthenticationServiceTest {
 
         when(userService.findByEmail("test@example.com")).thenReturn(Optional.of(user));
 
-        assertThrows(InvalidCredentialsException.class, () ->
-                authenticationService.resetPassword("test@example.com", "newPassword", null)
-        );
+        assertThrows(InvalidCredentialsException.class,
+                () -> authenticationService.resetPassword("test@example.com", "newPassword", null));
 
         verify(userService, never()).save(any(User.class));
     }
@@ -440,9 +464,8 @@ class AuthenticationServiceTest {
 
         when(refreshTokenService.getAndVerifyRefreshToken(invalidRefreshToken)).thenReturn(Optional.empty());
 
-        Exception exception = assertThrows(InvalidCredentialsException.class, () ->
-                authenticationService.renewRefreshToken(invalidRefreshToken)
-        );
+        Exception exception = assertThrows(InvalidCredentialsException.class,
+                () -> authenticationService.renewRefreshToken(invalidRefreshToken));
         assertEquals("Invalid token provided", exception.getMessage());
     }
 

--- a/src/test/java/com/safetypin/authentication/service/ProfileServiceTest.java
+++ b/src/test/java/com/safetypin/authentication/service/ProfileServiceTest.java
@@ -1,12 +1,28 @@
 package com.safetypin.authentication.service;
 
-import com.safetypin.authentication.dto.*;
-import com.safetypin.authentication.exception.InvalidCredentialsException;
-import com.safetypin.authentication.exception.ResourceNotFoundException;
-import com.safetypin.authentication.model.ProfileView;
-import com.safetypin.authentication.model.Role;
-import com.safetypin.authentication.model.User;
-import com.safetypin.authentication.repository.ProfileViewRepository;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,13 +36,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
-import java.util.*;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import com.safetypin.authentication.dto.PostedByData;
+import com.safetypin.authentication.dto.ProfileResponse;
+import com.safetypin.authentication.dto.ProfileViewDTO;
+import com.safetypin.authentication.dto.UpdateProfileRequest;
+import com.safetypin.authentication.dto.UserPostResponse;
+import com.safetypin.authentication.exception.InvalidCredentialsException;
+import com.safetypin.authentication.exception.ResourceNotFoundException;
+import com.safetypin.authentication.model.ProfileView;
+import com.safetypin.authentication.model.Role;
+import com.safetypin.authentication.model.User;
+import com.safetypin.authentication.repository.ProfileViewRepository;
 
 @ExtendWith(MockitoExtension.class)
 class ProfileServiceTest {
@@ -429,6 +449,30 @@ class ProfileServiceTest {
 
             verify(userService, times(1)).findById(userId);
             verify(userService, times(1)).save(any(User.class));
+        }
+
+        @Test
+        void updateProfile_NameTooLong_ThrowsIllegalArgumentException() {
+            // Arrange
+            when(userService.findById(userId)).thenReturn(Optional.of(testUser));
+
+            // Create a name that's 101 characters long
+            StringBuilder longName = new StringBuilder();
+            for (int i = 0; i < 101; i++) {
+                longName.append("a");
+            }
+
+            UpdateProfileRequest request = new UpdateProfileRequest();
+            request.setName(longName.toString());
+
+            // Act & Assert
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> profileService.updateProfile(userId, request));
+
+            assertEquals("Name must not exceed 100 characters", exception.getMessage());
+            verify(userService, times(1)).findById(userId);
+            verify(userService, never()).save(any(User.class));
         }
     }
 

--- a/src/test/java/com/safetypin/authentication/service/ProfileServiceTest.java
+++ b/src/test/java/com/safetypin/authentication/service/ProfileServiceTest.java
@@ -1,16 +1,27 @@
 package com.safetypin.authentication.service;
 
-import com.safetypin.authentication.dto.PostedByData;
-import com.safetypin.authentication.dto.ProfileResponse;
-import com.safetypin.authentication.dto.ProfileViewDTO;
-import com.safetypin.authentication.dto.UpdateProfileRequest;
-import com.safetypin.authentication.dto.UserPostResponse;
-import com.safetypin.authentication.exception.InvalidCredentialsException;
-import com.safetypin.authentication.exception.ResourceNotFoundException;
-import com.safetypin.authentication.model.Role;
-import com.safetypin.authentication.model.User;
-import com.safetypin.authentication.model.ProfileView;
-import com.safetypin.authentication.repository.ProfileViewRepository;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -25,14 +36,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.lang.reflect.Method;
-import java.time.LocalDateTime;
-import java.util.*;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import com.safetypin.authentication.dto.PostedByData;
+import com.safetypin.authentication.dto.ProfileResponse;
+import com.safetypin.authentication.dto.ProfileViewDTO;
+import com.safetypin.authentication.dto.UpdateProfileRequest;
+import com.safetypin.authentication.dto.UserPostResponse;
+import com.safetypin.authentication.exception.InvalidCredentialsException;
+import com.safetypin.authentication.exception.ResourceNotFoundException;
+import com.safetypin.authentication.model.ProfileView;
+import com.safetypin.authentication.model.Role;
+import com.safetypin.authentication.model.User;
+import com.safetypin.authentication.repository.ProfileViewRepository;
 
 @ExtendWith(MockitoExtension.class)
 class ProfileServiceTest {
@@ -123,8 +137,7 @@ class ProfileServiceTest {
             // Act & Assert
             ResourceNotFoundException exception = assertThrows(
                     ResourceNotFoundException.class,
-                    () -> profileService.getProfile(userId, null)
-            );
+                    () -> profileService.getProfile(userId, null));
 
             assertEquals("User not found with id " + userId, exception.getMessage());
             verify(userService, times(1)).findById(userId);
@@ -224,8 +237,7 @@ class ProfileServiceTest {
             // Act & Assert
             ResourceNotFoundException exception = assertThrows(
                     ResourceNotFoundException.class,
-                    () -> profileService.getProfile(userId, viewerId)
-            );
+                    () -> profileService.getProfile(userId, viewerId));
 
             assertTrue(exception.getMessage().contains("Viewer not found with id"));
             assertTrue(exception.getMessage().contains(viewerId.toString()));
@@ -271,7 +283,6 @@ class ProfileServiceTest {
         }
     }
 
-
     @Nested
     @DisplayName("updateProfile Tests")
     class UpdateProfileTests {
@@ -309,8 +320,7 @@ class ProfileServiceTest {
             // Act & Assert
             ResourceNotFoundException exception = assertThrows(
                     ResourceNotFoundException.class,
-                    () -> profileService.updateProfile(userId, request)
-            );
+                    () -> profileService.updateProfile(userId, request));
 
             assertTrue(exception.getMessage().contains("User not found with id"));
             assertTrue(exception.getMessage().contains(userId.toString()));
@@ -381,6 +391,66 @@ class ProfileServiceTest {
             verify(userService, times(1)).findById(userId);
             verify(userService, times(1)).save(any(User.class));
         }
+
+        @Test
+        void updateProfile_WithNameField_UpdatesUserName() {
+            // Arrange
+            when(userService.findById(userId)).thenReturn(Optional.of(testUser));
+            when(userService.save(any(User.class))).thenAnswer(invocation -> {
+                User savedUser = invocation.getArgument(0);
+                return savedUser;
+            });
+
+            UpdateProfileRequest request = new UpdateProfileRequest();
+            request.setName("New Test Name"); // Only updating the name
+
+            // Act
+            ProfileResponse response = profileService.updateProfile(userId, request);
+
+            // Assert
+            assertNotNull(response);
+            assertEquals("New Test Name", response.getName());
+
+            // Verify user was saved with the new name
+            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+            verify(userService).save(userCaptor.capture());
+            User savedUser = userCaptor.getValue();
+            assertEquals("New Test Name", savedUser.getName());
+
+            verify(userService, times(1)).findById(userId);
+            verify(userService, times(1)).save(any(User.class));
+        }
+
+        @Test
+        void updateProfile_WithNameAndOtherFields_UpdatesAllProvidedFields() {
+            // Arrange
+            when(userService.findById(userId)).thenReturn(Optional.of(testUser));
+            when(userService.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            UpdateProfileRequest request = new UpdateProfileRequest();
+            request.setName("New Test Name");
+            request.setInstagram("instagram.com/newinsta");
+            request.setProfilePicture("new-profile-pic.jpg");
+
+            // Act
+            ProfileResponse response = profileService.updateProfile(userId, request);
+
+            // Assert
+            assertNotNull(response);
+            assertEquals("New Test Name", response.getName());
+            assertEquals("newinsta", response.getInstagram());
+            assertEquals("new-profile-pic.jpg", response.getProfilePicture());
+
+            // Original values should be maintained for fields not in request
+            assertEquals("testtwitter", response.getTwitter());
+            assertEquals("testline", response.getLine());
+            assertEquals("testtiktok", response.getTiktok());
+            assertEquals("testdiscord", response.getDiscord());
+            assertEquals("banner.jpg", response.getProfileBanner());
+
+            verify(userService, times(1)).findById(userId);
+            verify(userService, times(1)).save(any(User.class));
+        }
     }
 
     @Nested
@@ -443,7 +513,8 @@ class ProfileServiceTest {
     class ExtractionLogicTests {
         @ParameterizedTest
         @MethodSource("provideUsernameCases")
-        void extractUsername_FromInput_ReturnsCleanedUsername(String methodName, String expected, String input) throws Exception {
+        void extractUsername_FromInput_ReturnsCleanedUsername(String methodName, String expected, String input)
+                throws Exception {
             // Use reflection to access private method
             java.lang.reflect.Method method = ProfileService.class.getDeclaredMethod(methodName, String.class);
             method.setAccessible(true);
@@ -521,8 +592,7 @@ class ProfileServiceTest {
                     // 3. Null or empty cases
                     Arguments.of("extractDiscordId", null, null),
                     Arguments.of("extractDiscordId", null, ""),
-                    Arguments.of("extractDiscordId", null, " ")
-            );
+                    Arguments.of("extractDiscordId", null, " "));
         }
     }
 
@@ -696,8 +766,7 @@ class ProfileServiceTest {
             // Act & Assert
             InvalidCredentialsException exception = assertThrows(
                     InvalidCredentialsException.class,
-                    () -> profileService.getProfileViews(userId)
-            );
+                    () -> profileService.getProfileViews(userId));
 
             assertEquals("You need to be a premium user to view profile views.", exception.getMessage());
             verify(userService, times(1)).findById(userId);
@@ -712,8 +781,7 @@ class ProfileServiceTest {
             // Act & Assert
             ResourceNotFoundException exception = assertThrows(
                     ResourceNotFoundException.class,
-                    () -> profileService.getProfileViews(userId)
-            );
+                    () -> profileService.getProfileViews(userId));
 
             assertEquals("User not found with id " + userId, exception.getMessage());
             verify(userService, times(1)).findById(userId);

--- a/src/test/java/com/safetypin/authentication/service/ProfileServiceTest.java
+++ b/src/test/java/com/safetypin/authentication/service/ProfileServiceTest.java
@@ -1,28 +1,12 @@
 package com.safetypin.authentication.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Stream;
-
+import com.safetypin.authentication.dto.*;
+import com.safetypin.authentication.exception.InvalidCredentialsException;
+import com.safetypin.authentication.exception.ResourceNotFoundException;
+import com.safetypin.authentication.model.ProfileView;
+import com.safetypin.authentication.model.Role;
+import com.safetypin.authentication.model.User;
+import com.safetypin.authentication.repository.ProfileViewRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -36,17 +20,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.safetypin.authentication.dto.PostedByData;
-import com.safetypin.authentication.dto.ProfileResponse;
-import com.safetypin.authentication.dto.ProfileViewDTO;
-import com.safetypin.authentication.dto.UpdateProfileRequest;
-import com.safetypin.authentication.dto.UserPostResponse;
-import com.safetypin.authentication.exception.InvalidCredentialsException;
-import com.safetypin.authentication.exception.ResourceNotFoundException;
-import com.safetypin.authentication.model.ProfileView;
-import com.safetypin.authentication.model.Role;
-import com.safetypin.authentication.model.User;
-import com.safetypin.authentication.repository.ProfileViewRepository;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ProfileServiceTest {
@@ -397,8 +377,7 @@ class ProfileServiceTest {
             // Arrange
             when(userService.findById(userId)).thenReturn(Optional.of(testUser));
             when(userService.save(any(User.class))).thenAnswer(invocation -> {
-                User savedUser = invocation.getArgument(0);
-                return savedUser;
+                return invocation.getArgument(0);
             });
 
             UpdateProfileRequest request = new UpdateProfileRequest();
@@ -511,19 +490,6 @@ class ProfileServiceTest {
     @Nested
     @DisplayName("Extraction Logic Tests (Private Methods)")
     class ExtractionLogicTests {
-        @ParameterizedTest
-        @MethodSource("provideUsernameCases")
-        void extractUsername_FromInput_ReturnsCleanedUsername(String methodName, String expected, String input)
-                throws Exception {
-            // Use reflection to access private method
-            java.lang.reflect.Method method = ProfileService.class.getDeclaredMethod(methodName, String.class);
-            method.setAccessible(true);
-
-            // Test the extraction
-            String result = (String) method.invoke(profileService, input);
-            assertEquals(expected, result);
-        }
-
         static Stream<Arguments> provideUsernameCases() {
             return Stream.of(
                     // Instagram cases
@@ -593,6 +559,19 @@ class ProfileServiceTest {
                     Arguments.of("extractDiscordId", null, null),
                     Arguments.of("extractDiscordId", null, ""),
                     Arguments.of("extractDiscordId", null, " "));
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideUsernameCases")
+        void extractUsername_FromInput_ReturnsCleanedUsername(String methodName, String expected, String input)
+                throws Exception {
+            // Use reflection to access private method
+            java.lang.reflect.Method method = ProfileService.class.getDeclaredMethod(methodName, String.class);
+            method.setAccessible(true);
+
+            // Test the extraction
+            String result = (String) method.invoke(profileService, input);
+            assertEquals(expected, result);
         }
     }
 


### PR DESCRIPTION
Previously, usernames were immutable after account creation, causing friction when someone needed to change their display handle. Now we can edit username of the user.