### PR TITLE
[REFACTOR] Standardize API Responses & Extract JWT Handling

### DIFF
--- a/src/main/java/com/safetypin/authentication/constants/ApiConstants.java
+++ b/src/main/java/com/safetypin/authentication/constants/ApiConstants.java
@@ -1,0 +1,25 @@
+package com.safetypin.authentication.constants;
+
+public class ApiConstants {
+    // Private constructor to prevent instantiation
+    private ApiConstants() {
+        // Utility class, do not instantiate
+    }
+    
+    // Response status values
+    public static final String STATUS_SUCCESS = "success";
+    public static final String STATUS_ERROR = "error";
+    
+    // Prefix constants
+    public static final String BEARER_PREFIX = "Bearer ";
+    
+    // Common messages
+    public static final String MSG_OPERATION_SUCCESS = "Operation completed successfully";
+    public static final String MSG_PROFILE_RETRIEVED = "Profile retrieved successfully";
+    public static final String MSG_PROFILE_UPDATED = "Profile updated successfully";
+    public static final String MSG_PROFILE_VIEWS = "Profile views retrieved successfully";
+    public static final String MSG_USERS_BATCH = "Users batch retrieved successfully";
+    public static final String MSG_FOLLOWERS_RETRIEVED = "Followers retrieved successfully";
+    public static final String MSG_FOLLOWING_RETRIEVED = "Following list retrieved successfully";
+    public static final String MSG_FOLLOW_STATS = "Follow statistics retrieved successfully";
+}

--- a/src/main/java/com/safetypin/authentication/controller/FollowController.java
+++ b/src/main/java/com/safetypin/authentication/controller/FollowController.java
@@ -6,42 +6,31 @@ import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import com.safetypin.authentication.dto.FollowStats;
-import com.safetypin.authentication.dto.FollowerNotificationDTO;
-import com.safetypin.authentication.dto.UserFollowResponse;
-import com.safetypin.authentication.dto.UserResponse;
-import com.safetypin.authentication.dto.ApiResponse;
+import com.safetypin.authentication.constants.ApiConstants;
+import com.safetypin.authentication.dto.*;
 import com.safetypin.authentication.service.FollowService;
-import com.safetypin.authentication.service.JwtService;
+import com.safetypin.authentication.util.JwtUtils;
 
 @RestController
 @RequestMapping("/api/follow")
 public class FollowController {
     private final FollowService followService;
-    private final JwtService jwtService;
-    private static final String BEARER_PREFIX = "Bearer ";
-    private static final String STATUS_SUCCESS = "success";
+    private final JwtUtils jwtUtils;
 
     @Autowired
-    public FollowController(FollowService followService, JwtService jwtService) {
+    public FollowController(FollowService followService, JwtUtils jwtUtils) {
         this.followService = followService;
-        this.jwtService = jwtService;
+        this.jwtUtils = jwtUtils;
     }
 
     @PostMapping("/{userIdToFollow}")
     public ResponseEntity<Void> followUser(
             @PathVariable UUID userIdToFollow,
             @RequestHeader("Authorization") String authHeader) {
-        String token = authHeader.replace(BEARER_PREFIX, "");
-        UserResponse user = jwtService.getUserFromJwtToken(token);
+        
+        UserResponse user = jwtUtils.parseUserFromAuthHeader(authHeader);
         UUID currentUserId = user.getId();
 
         followService.followUser(currentUserId, userIdToFollow);
@@ -53,8 +42,7 @@ public class FollowController {
             @PathVariable UUID userIdToUnfollow,
             @RequestHeader("Authorization") String authHeader) {
 
-        String token = authHeader.replace(BEARER_PREFIX, "");
-        UserResponse user = jwtService.getUserFromJwtToken(token);
+        UserResponse user = jwtUtils.parseUserFromAuthHeader(authHeader);
         UUID currentUserId = user.getId();
 
         followService.unfollowUser(currentUserId, userIdToUnfollow);
@@ -66,13 +54,13 @@ public class FollowController {
             @PathVariable UUID userId,
             @RequestHeader("Authorization") String authHeader) {
         
-        String token = authHeader.replace(BEARER_PREFIX, "");
-        UserResponse currentUser = jwtService.getUserFromJwtToken(token);
+        UserResponse currentUser = jwtUtils.parseUserFromAuthHeader(authHeader);
         UUID viewerId = currentUser.getId();
         
         List<UserFollowResponse> followers = followService.getFollowers(userId, viewerId);
         ApiResponse<List<UserFollowResponse>> response = ApiResponse.<List<UserFollowResponse>>builder()
-                .status(STATUS_SUCCESS)
+                .status(ApiConstants.STATUS_SUCCESS)
+                .success(true)
                 .data(followers)
                 .message("Followers retrieved successfully")
                 .build();
@@ -85,13 +73,13 @@ public class FollowController {
             @PathVariable UUID userId,
             @RequestHeader("Authorization") String authHeader) {
         
-        String token = authHeader.replace(BEARER_PREFIX, "");
-        UserResponse currentUser = jwtService.getUserFromJwtToken(token);
+        UserResponse currentUser = jwtUtils.parseUserFromAuthHeader(authHeader);
         UUID viewerId = currentUser.getId();
         
         List<UserFollowResponse> following = followService.getFollowing(userId, viewerId);
         ApiResponse<List<UserFollowResponse>> response = ApiResponse.<List<UserFollowResponse>>builder()
-                .status(STATUS_SUCCESS)
+                .status(ApiConstants.STATUS_SUCCESS)
+                .success(true)
                 .data(following)
                 .message("Following list retrieved successfully")
                 .build();
@@ -102,29 +90,35 @@ public class FollowController {
     @GetMapping("/stats/{userId}")
     public ResponseEntity<ApiResponse<FollowStats>> getFollowStats(
             @PathVariable UUID userId,
-            @RequestHeader(value = "Authorization") String authHeader) {
+            @RequestHeader(value = "Authorization", required = false) String authHeader) {
 
         boolean isFollowing = false;
 
-        try {
-            String token = authHeader.replace(BEARER_PREFIX, "");
-            UserResponse user = jwtService.getUserFromJwtToken(token);
-            UUID currentUserId = user.getId();
-
-            isFollowing = followService.isFollowing(currentUserId, userId);
-        } catch (Exception e) {
-            // Invalid token, keep isFollowing as false
+        if (authHeader != null && !authHeader.isEmpty()) {
+            try {
+                UserResponse user = jwtUtils.parseUserFromAuthHeader(authHeader);
+                UUID currentUserId = user.getId();
+                isFollowing = followService.isFollowing(currentUserId, userId);
+            } catch (Exception e) {
+                // Invalid token, keep isFollowing as false
+            }
         }
 
+        // Get followers and following counts
+        long followersCount = followService.getFollowersCount(userId);
+        long followingCount = followService.getFollowingCount(userId);
+
         FollowStats stats = FollowStats.builder()
-                .followersCount(followService.getFollowersCount(userId))
-                .followingCount(followService.getFollowingCount(userId))
+                .followersCount(followersCount)
+                .followingCount(followingCount)
                 .isFollowing(isFollowing)
                 .build();
+        
         ApiResponse<FollowStats> response = ApiResponse.<FollowStats>builder()
-                .status(STATUS_SUCCESS)
+                .status(ApiConstants.STATUS_SUCCESS)
+                .success(true)
                 .data(stats)
-                .message("Follow statistics retrieved successfully")
+                .message(ApiConstants.MSG_FOLLOW_STATS)
                 .build();
 
         return ResponseEntity.ok(response);
@@ -140,8 +134,7 @@ public class FollowController {
     public ResponseEntity<List<FollowerNotificationDTO>> getRecentFollowers(
             @RequestHeader("Authorization") String authHeader) {
 
-        String token = authHeader.replace(BEARER_PREFIX, "");
-        UserResponse user = jwtService.getUserFromJwtToken(token);
+        UserResponse user = jwtUtils.parseUserFromAuthHeader(authHeader);
         UUID currentUserId = user.getId();
 
         List<FollowerNotificationDTO> recentFollowers = followService.getRecentFollowers(currentUserId);

--- a/src/main/java/com/safetypin/authentication/controller/ProfileController.java
+++ b/src/main/java/com/safetypin/authentication/controller/ProfileController.java
@@ -1,10 +1,11 @@
 package com.safetypin.authentication.controller;
 
+import com.safetypin.authentication.constants.ApiConstants;
 import com.safetypin.authentication.dto.*;
 import com.safetypin.authentication.exception.InvalidCredentialsException;
 import com.safetypin.authentication.exception.ResourceNotFoundException;
-import com.safetypin.authentication.service.JwtService;
 import com.safetypin.authentication.service.ProfileService;
+import com.safetypin.authentication.util.JwtUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,113 +19,100 @@ import java.util.UUID;
 @RequestMapping("/api/profiles")
 public class ProfileController {
     private final ProfileService profileService;
-
-    private final JwtService jwtService;
+    private final JwtUtils jwtUtils;
 
     @Autowired
-    public ProfileController(ProfileService profileService, JwtService jwtService) {
+    public ProfileController(ProfileService profileService, JwtUtils jwtUtils) {
         this.profileService = profileService;
-        this.jwtService = jwtService;
+        this.jwtUtils = jwtUtils;
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<AuthResponse> getProfile(@PathVariable UUID id, @RequestHeader("Authorization") String authHeader) {
-        UUID viewerId;
-        try {
-            // Extract viewer ID from JWT token
-            UserResponse viewer = parseUserResponseFromAuthHeader(authHeader);
+    public ResponseEntity<ApiResponse<ProfileResponse>> getProfile(@PathVariable UUID id, @RequestHeader("Authorization") String authHeader) {
+        UUID viewerId = null;
+        UserResponse viewer = jwtUtils.parseUserFromAuthHeaderSafe(authHeader);
+        if (viewer != null) {
             viewerId = viewer.getId();
-        } catch (Exception e) { viewerId = null; /* If token is not present or invalid, viewerId remains null */ }
+        }
 
         try {
             ProfileResponse profile = profileService.getProfile(id, viewerId);
-            return ResponseEntity.ok(new AuthResponse(true, "Profile retrieved successfully", profile));
+            return ResponseEntity.ok(ApiResponse.success(ApiConstants.MSG_PROFILE_RETRIEVED, profile));
         } catch (ResourceNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new AuthResponse(false, e.getMessage(), null));
+                    .body(ApiResponse.error(e.getMessage()));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new AuthResponse(false, "Error retrieving profile: " + e.getMessage(), null));
+                    .body(ApiResponse.error("Error retrieving profile: " + e.getMessage()));
         }
     }
 
     @GetMapping("/me")
-    public ResponseEntity<AuthResponse> getMyProfile(@RequestHeader("Authorization") String authHeader) {
+    public ResponseEntity<ApiResponse<ProfileResponse>> getMyProfile(@RequestHeader("Authorization") String authHeader) {
         try {
-            // Extract user ID from JWT token
-            UserResponse user = parseUserResponseFromAuthHeader(authHeader);
+            UserResponse user = jwtUtils.parseUserFromAuthHeader(authHeader);
             UUID id = user.getId();
             
             ProfileResponse profile = profileService.getProfile(id, id);
-            return ResponseEntity.ok(new AuthResponse(true, "Profile retrieved successfully", profile));
+            return ResponseEntity.ok(ApiResponse.success(ApiConstants.MSG_PROFILE_RETRIEVED, profile));
         } catch (InvalidCredentialsException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(new AuthResponse(false, e.getMessage(), null));
+                    .body(ApiResponse.error(e.getMessage()));
         } catch (ResourceNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new AuthResponse(false, e.getMessage(), null));
+                    .body(ApiResponse.error(e.getMessage()));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new AuthResponse(false, "Error retrieving profile: " + e.getMessage(), null));
+                    .body(ApiResponse.error("Error retrieving profile: " + e.getMessage()));
         }
     }
 
     @PutMapping("/me")
-    public ResponseEntity<AuthResponse> updateMyProfile(
+    public ResponseEntity<ApiResponse<ProfileResponse>> updateMyProfile(
             @RequestBody UpdateProfileRequest request,
             @RequestHeader("Authorization") String authHeader) {
 
         try { 
-            UserResponse user = parseUserResponseFromAuthHeader(authHeader);
+            UserResponse user = jwtUtils.parseUserFromAuthHeader(authHeader);
             UUID id = user.getId();
 
             ProfileResponse updatedProfile = profileService.updateProfile(id, request);
-            return ResponseEntity.ok(new AuthResponse(true, "Profile updated successfully", updatedProfile));
+            return ResponseEntity.ok(ApiResponse.success(ApiConstants.MSG_PROFILE_UPDATED, updatedProfile));
         } catch (InvalidCredentialsException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(new AuthResponse(false, e.getMessage(), null));
+                    .body(ApiResponse.error(e.getMessage()));
         } catch (ResourceNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new AuthResponse(false, e.getMessage(), null));
+                    .body(ApiResponse.error(e.getMessage()));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new AuthResponse(false, "Error updating profile: " + e.getMessage(), null));
+                    .body(ApiResponse.error("Error updating profile: " + e.getMessage()));
         }
     }
 
     @GetMapping("/me/views")
-    public ResponseEntity<AuthResponse> getProfileViews(@RequestHeader("Authorization") String authHeader) {
+    public ResponseEntity<ApiResponse<List<ProfileViewDTO>>> getProfileViews(@RequestHeader("Authorization") String authHeader) {
         try {
-            UserResponse user = parseUserResponseFromAuthHeader(authHeader);
+            UserResponse user = jwtUtils.parseUserFromAuthHeader(authHeader);
             UUID userId = user.getId();
 
             List<ProfileViewDTO> profileViews = profileService.getProfileViews(userId);
-            return ResponseEntity.ok(new AuthResponse(true, "Profile views retrieved successfully", profileViews));
+            return ResponseEntity.ok(ApiResponse.success(ApiConstants.MSG_PROFILE_VIEWS, profileViews));
         } catch (InvalidCredentialsException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(new AuthResponse(false, e.getMessage(), null));
+                    .body(ApiResponse.error(e.getMessage()));
         } catch (ResourceNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new AuthResponse(false, e.getMessage(), null));
+                    .body(ApiResponse.error(e.getMessage()));
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new AuthResponse(false, "Error retrieving profile views: " + e.getMessage(), null));
+                    .body(ApiResponse.error("Error retrieving profile views: " + e.getMessage()));
         }
     }
 
     @PostMapping("/batch")
-    public Map<UUID, PostedByData> getUsersBatch(@RequestBody List<UUID> userIds) {
-        return profileService.getUsersBatch(userIds);
-    }
-
-    private UserResponse parseUserResponseFromAuthHeader(String authHeader) throws InvalidCredentialsException {
-        String token = authHeader.replace("Bearer ", "");
-        try {
-            return jwtService.getUserFromJwtToken(token);
-        } catch (InvalidCredentialsException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new InvalidCredentialsException("Invalid token");
-        }
+    public ResponseEntity<ApiResponse<Map<UUID, PostedByData>>> getUsersBatch(@RequestBody List<UUID> userIds) {
+        Map<UUID, PostedByData> batchData = profileService.getUsersBatch(userIds);
+        return ResponseEntity.ok(ApiResponse.success(ApiConstants.MSG_USERS_BATCH, batchData));
     }
 }

--- a/src/main/java/com/safetypin/authentication/dto/ApiResponse.java
+++ b/src/main/java/com/safetypin/authentication/dto/ApiResponse.java
@@ -6,11 +6,57 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ApiResponse<T> {
     private String status;
+    private boolean success;
     private T data;
     private String message;
+    
+    // Custom builder to support chaining
+    public static class ApiResponseBuilder<T> {
+        private String status;
+        private boolean success;
+        private T data;
+        private String message;
+        
+        public ApiResponseBuilder<T> status(String status) {
+            this.status = status;
+            return this;
+        }
+        
+        public ApiResponseBuilder<T> success(boolean success) {
+            this.success = success;
+            return this;
+        }
+        
+        public ApiResponseBuilder<T> data(T data) {
+            this.data = data;
+            return this;
+        }
+        
+        public ApiResponseBuilder<T> message(String message) {
+            this.message = message;
+            return this;
+        }
+        
+        public ApiResponse<T> build() {
+            return new ApiResponse<>(status, success, data, message);
+        }
+    }
+    
+    // Static factory methods for easier creation
+    public static <T> ApiResponseBuilder<T> builder() {
+        return new ApiResponseBuilder<>();
+    }
+    
+    // Convenience methods for creating success/error responses
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>("success", true, data, message);
+    }
+    
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>("error", false, null, message);
+    }
 }

--- a/src/main/java/com/safetypin/authentication/util/JwtUtils.java
+++ b/src/main/java/com/safetypin/authentication/util/JwtUtils.java
@@ -1,0 +1,49 @@
+package com.safetypin.authentication.util;
+
+import com.safetypin.authentication.constants.ApiConstants;
+import com.safetypin.authentication.dto.UserResponse;
+import com.safetypin.authentication.exception.InvalidCredentialsException;
+import com.safetypin.authentication.service.JwtService;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtils {
+    
+    private final JwtService jwtService;
+    
+    public JwtUtils(JwtService jwtService) {
+        this.jwtService = jwtService;
+    }
+    
+    /**
+     * Extracts and validates a UserResponse from the Authorization header
+     * 
+     * @param authHeader The Authorization header containing the JWT token
+     * @return The UserResponse object extracted from the token
+     * @throws InvalidCredentialsException If the token is invalid or expired
+     */
+    public UserResponse parseUserFromAuthHeader(String authHeader) throws InvalidCredentialsException {
+        String token = authHeader.replace(ApiConstants.BEARER_PREFIX, "");
+        try {
+            return jwtService.getUserFromJwtToken(token);
+        } catch (InvalidCredentialsException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new InvalidCredentialsException("Invalid token");
+        }
+    }
+    
+    /**
+     * Tries to extract a UserResponse from the Authorization header, returns null on failure
+     * 
+     * @param authHeader The Authorization header containing the JWT token
+     * @return The UserResponse object or null if extraction fails
+     */
+    public UserResponse parseUserFromAuthHeaderSafe(String authHeader) {
+        try {
+            return parseUserFromAuthHeader(authHeader);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/safetypin/authentication/controller/UserProfileBatchControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/UserProfileBatchControllerTest.java
@@ -1,8 +1,10 @@
 package com.safetypin.authentication.controller;
 
+import com.safetypin.authentication.constants.ApiConstants;
+import com.safetypin.authentication.dto.ApiResponse;
 import com.safetypin.authentication.dto.PostedByData;
-import com.safetypin.authentication.service.JwtService;
 import com.safetypin.authentication.service.ProfileService;
+import com.safetypin.authentication.util.JwtUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,6 +12,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 import java.util.*;
 
@@ -17,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
@@ -28,7 +33,7 @@ class ProfileControllerBatchEndpointTest {
     private ProfileService profileService;
 
     @Mock
-    private JwtService jwtService;
+    private JwtUtils jwtUtils;
 
     @InjectMocks
     private ProfileController profileController;
@@ -66,15 +71,24 @@ class ProfileControllerBatchEndpointTest {
         when(profileService.getUsersBatch(userIds)).thenReturn(postedByDataMap);
 
         // Act
-        Map<UUID, PostedByData> responseMap = profileController.getUsersBatch(userIds);
+        ResponseEntity<ApiResponse<Map<UUID, PostedByData>>> response = profileController.getUsersBatch(userIds);
 
         // Assert
-        assertNotNull(responseMap);
-        assertThat(responseMap, aMapWithSize(2));
-        assertThat(responseMap, hasEntry(is(userId1), is(profile1)));
-        assertThat(responseMap, hasEntry(is(userId2), is(profile2)));
-        assertEquals("User One", responseMap.get(userId1).getName());
-        assertEquals("pic2.jpg", responseMap.get(userId2).getProfilePicture());
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        
+        ApiResponse<Map<UUID, PostedByData>> apiResponse = response.getBody();
+        assertNotNull(apiResponse);
+        assertTrue(apiResponse.isSuccess());
+        assertEquals(ApiConstants.STATUS_SUCCESS, apiResponse.getStatus());
+        assertEquals(ApiConstants.MSG_USERS_BATCH, apiResponse.getMessage());
+        
+        Map<UUID, PostedByData> responseData = apiResponse.getData();
+        assertThat(responseData, aMapWithSize(2));
+        assertThat(responseData, hasEntry(is(userId1), is(profile1)));
+        assertThat(responseData, hasEntry(is(userId2), is(profile2)));
+        assertEquals("User One", responseData.get(userId1).getName());
+        assertEquals("pic2.jpg", responseData.get(userId2).getProfilePicture());
 
         // Verify the service method was called
         verify(profileService, times(1)).getUsersBatch(userIds);
@@ -88,11 +102,20 @@ class ProfileControllerBatchEndpointTest {
         when(profileService.getUsersBatch(emptyList)).thenReturn(Collections.emptyMap());
 
         // Act
-        Map<UUID, PostedByData> responseMap = profileController.getUsersBatch(emptyList);
+        ResponseEntity<ApiResponse<Map<UUID, PostedByData>>> response = profileController.getUsersBatch(emptyList);
 
         // Assert
-        assertNotNull(responseMap);
-        assertThat(responseMap, aMapWithSize(0));
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        
+        ApiResponse<Map<UUID, PostedByData>> apiResponse = response.getBody();
+        assertNotNull(apiResponse);
+        assertTrue(apiResponse.isSuccess());
+        assertEquals(ApiConstants.STATUS_SUCCESS, apiResponse.getStatus());
+        assertEquals(ApiConstants.MSG_USERS_BATCH, apiResponse.getMessage());
+        
+        Map<UUID, PostedByData> responseData = apiResponse.getData();
+        assertThat(responseData, aMapWithSize(0));
 
         // Verify service method was called with the empty list
         verify(profileService, times(1)).getUsersBatch(emptyList);
@@ -105,11 +128,20 @@ class ProfileControllerBatchEndpointTest {
         when(profileService.getUsersBatch(isNull())).thenReturn(Collections.emptyMap());
 
         // Act
-        Map<UUID, PostedByData> responseMap = profileController.getUsersBatch(null);
+        ResponseEntity<ApiResponse<Map<UUID, PostedByData>>> response = profileController.getUsersBatch(null);
 
         // Assert
-        assertNotNull(responseMap);
-        assertThat(responseMap, aMapWithSize(0));
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        
+        ApiResponse<Map<UUID, PostedByData>> apiResponse = response.getBody();
+        assertNotNull(apiResponse);
+        assertTrue(apiResponse.isSuccess());
+        assertEquals(ApiConstants.STATUS_SUCCESS, apiResponse.getStatus());
+        assertEquals(ApiConstants.MSG_USERS_BATCH, apiResponse.getMessage());
+        
+        Map<UUID, PostedByData> responseData = apiResponse.getData();
+        assertThat(responseData, aMapWithSize(0));
 
         // Verify service method was called with null
         verify(profileService, times(1)).getUsersBatch(isNull());
@@ -127,13 +159,22 @@ class ProfileControllerBatchEndpointTest {
         when(profileService.getUsersBatch(requestedIds)).thenReturn(partialMap);
 
         // Act
-        Map<UUID, PostedByData> responseMap = profileController.getUsersBatch(requestedIds);
+        ResponseEntity<ApiResponse<Map<UUID, PostedByData>>> response = profileController.getUsersBatch(requestedIds);
 
         // Assert
-        assertNotNull(responseMap);
-        assertThat(responseMap, aMapWithSize(1));
-        assertThat(responseMap, hasEntry(is(userId1), is(profile1)));
-        assertThat(responseMap, not(hasKey(userId3)));
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        
+        ApiResponse<Map<UUID, PostedByData>> apiResponse = response.getBody();
+        assertNotNull(apiResponse);
+        assertTrue(apiResponse.isSuccess());
+        assertEquals(ApiConstants.STATUS_SUCCESS, apiResponse.getStatus());
+        assertEquals(ApiConstants.MSG_USERS_BATCH, apiResponse.getMessage());
+        
+        Map<UUID, PostedByData> responseData = apiResponse.getData();
+        assertThat(responseData, aMapWithSize(1));
+        assertThat(responseData, hasEntry(is(userId1), is(profile1)));
+        assertThat(responseData, not(hasKey(userId3)));
 
         // Verify the service method was called
         verify(profileService, times(1)).getUsersBatch(requestedIds);
@@ -146,11 +187,20 @@ class ProfileControllerBatchEndpointTest {
         when(profileService.getUsersBatch(userIds)).thenReturn(Collections.emptyMap());
 
         // Act
-        Map<UUID, PostedByData> responseMap = profileController.getUsersBatch(userIds);
+        ResponseEntity<ApiResponse<Map<UUID, PostedByData>>> response = profileController.getUsersBatch(userIds);
 
         // Assert
-        assertNotNull(responseMap);
-        assertThat(responseMap, aMapWithSize(0));
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        
+        ApiResponse<Map<UUID, PostedByData>> apiResponse = response.getBody();
+        assertNotNull(apiResponse);
+        assertTrue(apiResponse.isSuccess());
+        assertEquals(ApiConstants.STATUS_SUCCESS, apiResponse.getStatus());
+        assertEquals(ApiConstants.MSG_USERS_BATCH, apiResponse.getMessage());
+        
+        Map<UUID, PostedByData> responseData = apiResponse.getData();
+        assertThat(responseData, aMapWithSize(0));
 
         // Verify the service method was called
         verify(profileService, times(1)).getUsersBatch(userIds);


### PR DESCRIPTION
**Summary:**  
This PR refactors multiple controllers and test classes to introduce a standardized API response structure and centralize JWT handling logic.

**Changes:**
- Introduced `ApiResponse<T>` for consistent, type-safe API responses  
- Created `ApiConstants` for standard status codes and messages  
- Extracted JWT token parsing into a new `JwtUtils` utility class  
- Refactored controllers to use `ApiResponse` and `JwtUtils`  
- Updated relevant test classes to reflect new response format  
- Fixed potential `NullPointerException` in auth header parsing  
- Preserved `success` field for backward compatibility with frontend  

**Benefits:**
- Improved maintainability and type safety  
- Cleaner, DRY token handling  
- Consistent API behavior across endpoints
