### PR TITLE
Sanitize inputs, update dependencies, and refine auth error handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,12 +133,12 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Spring Boot Actuator for health checks -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>2.5.4</version>
-        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-actuator -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+			<version>3.4.5</version>
+		</dependency>
 
         <!-- Spring Data JPA -->
         <dependency>
@@ -152,12 +152,13 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
-        <!-- H2 Database for development/testing -->
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>runtime</scope>
-        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.h2database/h2 -->
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<version>2.3.232</version>
+			<scope>test</scope>
+		</dependency>
 
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/src/main/java/com/safetypin/authentication/dto/LoginRequest.java
+++ b/src/main/java/com/safetypin/authentication/dto/LoginRequest.java
@@ -1,6 +1,5 @@
 package com.safetypin.authentication.dto;
 
-
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,4 +10,7 @@ public class LoginRequest {
     private String email;
     private String password;
 
+    public void setEmail(String email) {
+        this.email = (email != null) ? email.trim() : null;
+    }
 }

--- a/src/main/java/com/safetypin/authentication/dto/OTPRequest.java
+++ b/src/main/java/com/safetypin/authentication/dto/OTPRequest.java
@@ -8,4 +8,12 @@ import lombok.Setter;
 public class OTPRequest {
     String email;
     String otp;
+
+    public void setEmail(String email) {
+        this.email = (email != null) ? email.trim() : null;
+    }
+
+    public void setOtp(String otp) {
+        this.otp = (otp != null) ? otp.trim() : null;
+    }
 }

--- a/src/main/java/com/safetypin/authentication/dto/PasswordResetRequest.java
+++ b/src/main/java/com/safetypin/authentication/dto/PasswordResetRequest.java
@@ -14,5 +14,8 @@ public class PasswordResetRequest {
     private String email;
 
     // Getters and setters
+    public void setEmail(String email) {
+        this.email = (email != null) ? email.trim() : null;
+    }
 
 }

--- a/src/main/java/com/safetypin/authentication/dto/PasswordResetWithOTPRequest.java
+++ b/src/main/java/com/safetypin/authentication/dto/PasswordResetWithOTPRequest.java
@@ -19,4 +19,12 @@ public class PasswordResetWithOTPRequest {
 
     @NotBlank(message = "Reset token is required")
     private String resetToken;
+
+    public void setEmail(String email) {
+        this.email = (email != null) ? email.trim() : null;
+    }
+
+    public void setResetToken(String resetToken) {
+        this.resetToken = (resetToken != null) ? resetToken.trim() : null;
+    }
 }

--- a/src/main/java/com/safetypin/authentication/dto/RegistrationRequest.java
+++ b/src/main/java/com/safetypin/authentication/dto/RegistrationRequest.java
@@ -1,12 +1,12 @@
 package com.safetypin.authentication.dto;
 
+import java.time.LocalDate;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.time.LocalDate;
 
 @Setter
 @Getter
@@ -26,5 +26,12 @@ public class RegistrationRequest {
     private LocalDate birthdate;
 
     // Getters and setters
+    public void setEmail(String email) {
+        this.email = (email != null) ? email.trim() : null;
+    }
+
+    public void setName(String name) {
+        this.name = (name != null) ? name.trim() : null;
+    }
 
 }

--- a/src/main/java/com/safetypin/authentication/dto/VerifyResetOTPRequest.java
+++ b/src/main/java/com/safetypin/authentication/dto/VerifyResetOTPRequest.java
@@ -16,7 +16,7 @@ public class VerifyResetOTPRequest {
     }
 
     public void setEmail(String email) {
-        this.email = email;
+        this.email = (email != null) ? email.trim() : null;
     }
 
     public String getOtp() {
@@ -24,6 +24,6 @@ public class VerifyResetOTPRequest {
     }
 
     public void setOtp(String otp) {
-        this.otp = otp;
+        this.otp = (otp != null) ? otp.trim() : null;
     }
 }

--- a/src/main/java/com/safetypin/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/safetypin/authentication/service/AuthenticationService.java
@@ -101,7 +101,7 @@ public class AuthenticationService {
         User user = findUser.get();
         if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
             // incorrect password
-            logger.warn("Login failed: Incorrect password for email: {}", email);
+            logger.debug("Login failed: Incorrect password for email: {}", email);
             throw new InvalidCredentialsException("Invalid email or password");
         }
         String accessToken = jwtService.generateToken(user.getId());

--- a/src/main/java/com/safetypin/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/safetypin/authentication/service/AuthenticationService.java
@@ -95,14 +95,14 @@ public class AuthenticationService {
         Optional<User> findUser = userService.findByEmail(email);
         if (findUser.isEmpty()) {
             // email not exists
-            logger.warn("Login failed: Email not found");
-            throw new InvalidCredentialsException("Invalid email");
+            logger.warn("Login failed: Email not found or incorrect password for email: {}", email);
+            throw new InvalidCredentialsException("Invalid email or password");
         }
         User user = findUser.get();
         if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
             // incorrect password
-            logger.warn("Login failed: Incorrect password attempt");
-            throw new InvalidCredentialsException("Invalid password");
+            logger.warn("Login failed: Email not found or incorrect password for email: {}", email);
+            throw new InvalidCredentialsException("Invalid email or password");
         }
         String accessToken = jwtService.generateToken(user.getId());
         RefreshToken refreshToken = refreshTokenService.createRefreshToken(user.getId());

--- a/src/main/java/com/safetypin/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/safetypin/authentication/service/AuthenticationService.java
@@ -95,13 +95,13 @@ public class AuthenticationService {
         Optional<User> findUser = userService.findByEmail(email);
         if (findUser.isEmpty()) {
             // email not exists
-            logger.warn("Login failed: Email not found or incorrect password for email: {}", email);
+            logger.warn("Login failed: Email not found for email: {}", email);
             throw new InvalidCredentialsException("Invalid email or password");
         }
         User user = findUser.get();
         if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
             // incorrect password
-            logger.warn("Login failed: Email not found or incorrect password for email: {}", email);
+            logger.warn("Login failed: Incorrect password for email: {}", email);
             throw new InvalidCredentialsException("Invalid email or password");
         }
         String accessToken = jwtService.generateToken(user.getId());

--- a/src/test/java/com/safetypin/authentication/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/safetypin/authentication/repository/FollowRepositoryTest.java
@@ -1,17 +1,21 @@
 package com.safetypin.authentication.repository;
 
-import com.safetypin.authentication.model.Follow;
-import com.safetypin.authentication.model.User;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
+import com.safetypin.authentication.model.Follow;
+import com.safetypin.authentication.model.User;
 
 @DataJpaTest
 class FollowRepositoryTest {
@@ -21,9 +25,6 @@ class FollowRepositoryTest {
 
     @Autowired
     private FollowRepository followRepository;
-
-    @Autowired
-    private UserRepository userRepository;
 
     private User follower;
     private User followee1;
@@ -150,7 +151,7 @@ class FollowRepositoryTest {
 
         // Assert
         assertFalse(followRepository.existsByFollowerIdAndFollowingId(follower.getId(), followee1.getId()));
-        
+
         // Verify other relationships are still intact
         assertTrue(followRepository.existsByFollowerIdAndFollowingId(follower.getId(), followee2.getId()));
         assertTrue(followRepository.existsByFollowerIdAndFollowingId(followee2.getId(), followee1.getId()));

--- a/src/test/java/com/safetypin/authentication/service/AuthenticationServiceTest.java
+++ b/src/test/java/com/safetypin/authentication/service/AuthenticationServiceTest.java
@@ -166,7 +166,7 @@ class AuthenticationServiceTest {
         Exception exception = assertThrows(InvalidCredentialsException.class,
                 () -> authenticationService.loginUser("notfound@example.com", "password"));
 
-        assertEquals("Invalid email", exception.getMessage());
+        assertEquals("Invalid email or password", exception.getMessage());
     }
 
     @Test
@@ -186,7 +186,7 @@ class AuthenticationServiceTest {
         Exception exception = assertThrows(InvalidCredentialsException.class,
                 () -> authenticationService.loginUser("test@example.com", "wrongPassword"));
 
-        assertEquals("Invalid password", exception.getMessage());
+        assertEquals("Invalid email or password", exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
This pull request includes updates to dependencies, introduces input sanitization for DTO classes, improves error handling in the authentication service, and adjusts related test cases. Below is a summary of the most important changes grouped by theme:

### Dependency Updates:
* Updated the version of `spring-boot-starter-actuator` from `2.5.4` to `3.4.5` in `pom.xml`.
* Added a version (`2.3.232`) for the `h2` database dependency and changed its scope from `runtime` to `test` in `pom.xml`.

### Input Sanitization:
* Added `setEmail` methods to trim email input in multiple DTO classes, including `LoginRequest`, `OTPRequest`, `PasswordResetRequest`, `PasswordResetWithOTPRequest`, `RegistrationRequest`, and `VerifyResetOTPRequest`. [[1]](diffhunk://#diff-27bd69aaf8763cbbae7e189a9caefa8c42ce5fd990b7bac3b55f47174db52277R13-R15) [[2]](diffhunk://#diff-c15e68e61acdde16e71aba09d1d3107330828882846a5c094903c408b7d553f5R11-R18) [[3]](diffhunk://#diff-9facea1d27c8ab3d14834010fee7fe957c58af00c0605734a8ca48de6b64d599R17-R19) [[4]](diffhunk://#diff-038ed21edf297ecfaf09f94473b99e4461a5657497dca1c30a56b3635df21496R22-R29) [[5]](diffhunk://#diff-79f9d605418eb57806a2cf56e704b22d8a5fb068fd78d0f1cb3e2e10f5012383R29-R35) [[6]](diffhunk://#diff-ba550781d1cb323ef62369de906db71af132977cec3cc03b206d7c1ea72d48bcL19-R27)
* Added `setName` and `setResetToken` methods to trim input in `RegistrationRequest` and `PasswordResetWithOTPRequest`, respectively. [[1]](diffhunk://#diff-79f9d605418eb57806a2cf56e704b22d8a5fb068fd78d0f1cb3e2e10f5012383R29-R35) [[2]](diffhunk://#diff-038ed21edf297ecfaf09f94473b99e4461a5657497dca1c30a56b3635df21496R22-R29)

### Error Handling Improvements:
* Updated error messages in `AuthenticationService` to provide more generic feedback for login failures, replacing specific messages with "Invalid email or password".

### Test Case Adjustments:
* Updated test cases in `AuthenticationServiceTest` to reflect the new generic error message "Invalid email or password". [[1]](diffhunk://#diff-dd92a90b3442e8c2930dbae7550276aa960f9a6337c5aea72fb0b0c3b53a998bL169-R169) [[2]](diffhunk://#diff-dd92a90b3442e8c2930dbae7550276aa960f9a6337c5aea72fb0b0c3b53a998bL189-R189)

### Code Cleanup:
* Removed unused `UserRepository` field in `FollowRepositoryTest` and reorganized imports for better readability. [[1]](diffhunk://#diff-cebdc829402d4a1440e1fb8f07ba50a84602b9c99f33bfd8541ced9bddb58657L3-R18) [[2]](diffhunk://#diff-cebdc829402d4a1440e1fb8f07ba50a84602b9c99f33bfd8541ced9bddb58657L25-L27)