### PR TITLE
Enhance Search Endpoint to Include and Sort by Follower Count

### DIFF
--- a/src/main/java/com/safetypin/authentication/dto/UserResponse.java
+++ b/src/main/java/com/safetypin/authentication/dto/UserResponse.java
@@ -1,12 +1,12 @@
 package com.safetypin.authentication.dto;
 
+import java.time.LocalDate;
+import java.util.UUID;
+
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.time.LocalDate;
-import java.util.UUID;
 
 @Data
 @Getter
@@ -26,9 +26,11 @@ public class UserResponse {
 
     private LocalDate birthdate;
 
-    private String provider;  // "EMAIL", "GOOGLE", "APPLE"
+    private String provider; // "EMAIL", "GOOGLE", "APPLE" private String profilePicture;
+
+    private String profileBanner;
 
     private String profilePicture;
 
-    private String profileBanner;
+    private long followersCount;
 }

--- a/src/test/java/com/safetypin/authentication/controller/SearchControllerTest.java
+++ b/src/test/java/com/safetypin/authentication/controller/SearchControllerTest.java
@@ -1,10 +1,22 @@
 package com.safetypin.authentication.controller;
 
-import com.safetypin.authentication.dto.UserResponse;
-import com.safetypin.authentication.model.Role;
-import com.safetypin.authentication.model.User;
-import com.safetypin.authentication.service.ProfileService;
-import com.safetypin.authentication.service.UserService;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,18 +29,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import com.safetypin.authentication.dto.UserResponse;
+import com.safetypin.authentication.model.Role;
+import com.safetypin.authentication.model.User;
+import com.safetypin.authentication.service.FollowService;
+import com.safetypin.authentication.service.ProfileService;
+import com.safetypin.authentication.service.UserService;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("SearchController Unit Tests")
@@ -39,6 +45,9 @@ class SearchControllerTest {
 
     @Mock
     private ProfileService profileService;
+
+    @Mock
+    private FollowService followService;
 
     @InjectMocks
     private SearchController searchController;
@@ -73,7 +82,12 @@ class SearchControllerTest {
         user3.setVerified(true);
 
         allUsers = Arrays.asList(user1, user2, user3);
-        johnUsers = Arrays.asList(user1, user3);
+        johnUsers = Arrays.asList(user1, user3); // Mock followService to return follower counts
+        // Order users by followers count: user1 > user2 > user3 to maintain the
+        // expected order in tests
+        lenient().when(followService.getFollowersCount(user1.getId())).thenReturn(30L);
+        lenient().when(followService.getFollowersCount(user2.getId())).thenReturn(20L);
+        lenient().when(followService.getFollowersCount(user3.getId())).thenReturn(10L);
     }
 
     @Nested


### PR DESCRIPTION
This pull request introduces changes to enhance the user search functionality by incorporating follower count into the search results, updating the `UserResponse` DTO, and adding corresponding unit tests. The most significant updates include sorting users by follower count, modifying the DTO to include a `followersCount` field, and updating the test suite to validate the new functionality.

### Enhancements to User Search Functionality:
* **Sorting by Follower Count**: Updated the `searchUsersByName` method in `SearchController` to sort users by follower count in descending order. This involved mapping users to `UserResponse` DTOs and fetching their follower counts using the new `FollowService`.
* **Dependency Injection**: Added `FollowService` as a dependency in the `SearchController` to fetch follower counts.

### Updates to `UserResponse` DTO:
* **New Field for Follower Count**: Added a `followersCount` field to the `UserResponse` DTO to store the follower count for each user.

### Unit Test Updates:
* **Mocking Follower Counts**: Updated `SearchControllerTest` to mock `FollowService` and provide follower counts for testing. This ensures that the sorting logic based on follower count is validated.
* **Test Imports and Setup**: Adjusted imports and added `FollowService` as a mocked dependency in `SearchControllerTest`. [[1]](diffhunk://#diff-2256161fdb788e0caa032f80d525e4fc40aa2bf98738fba5bf6ca095a5a876c0L3-R19) [[2]](diffhunk://#diff-2256161fdb788e0caa032f80d525e4fc40aa2bf98738fba5bf6ca095a5a876c0R49-R51)